### PR TITLE
package.json hygiene and readme fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,7 @@ on:
 
 jobs:
   build:
-    name: build on node@${{ matrix.node-version }}
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version:
-          - 24
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -23,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: package.json
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If you want to contribute, please follow these rules:
 
 1. **Open an Issue first:** Do not submit a Pull Request for new features, architecture changes, or major refactoring without discussing it in an issue first. Uncoordinated PRs will be closed.
 2. **No AI-generated bulk code:** I do not accept massive, AI-generated PRs. Code must be human-readable, minimalistic, and match the existing project style.
-3. **Pass the CI:** Make sure your code passes all strict type checks and linters. Run `npm run typecheck` and `npm run lint` locally before pushing.
+3. **Pass the CI:** Make sure your code passes all strict type checks and linters. Run `pnpm check` and `pnpm check:submission` locally before pushing.
 4. **Keep it small:** PRs should be strictly focused on a single issue. 
 
 Bug fixes and thoroughly discussed features are always welcome!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-manager",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "Obsidian Project Manager Plugin",
   "main": "main.js",
   "type": "module",
@@ -25,7 +25,7 @@
     "eslint": "9.39.4",
     "eslint-plugin-obsidianmd": "0.2.4",
     "npm-run-all2": "8.0.4",
-    "obsidian": "latest",
+    "obsidian": "1.12.3",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "tsdown": "0.21.9",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@2bad/tsconfig": "3.0.2",
     "@types/node": "25.6.0",
     "@typescript-eslint/parser": "8.59.0",
-    "builtin-modules": "3.3.0",
     "eslint": "9.39.4",
     "eslint-plugin-obsidianmd": "0.2.4",
     "npm-run-all2": "8.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: 8.59.0
         version: 8.59.0(eslint@9.39.4)(typescript@6.0.2)
-      builtin-modules:
-        specifier: 3.3.0
-        version: 3.3.0
       eslint:
         specifier: 9.39.4
         version: 9.39.4
@@ -781,10 +778,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  builtin-modules@3.3.0:
-    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
-    engines: {node: '>=6'}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -2611,8 +2604,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  builtin-modules@3.3.0: {}
 
   cac@7.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: 8.0.4
         version: 8.0.4
       obsidian:
-        specifier: latest
+        specifier: 1.12.3
         version: 1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       oxfmt:
         specifier: 0.46.0

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,4 +1,4 @@
-import builtins from 'builtin-modules'
+import { builtinModules } from 'node:module'
 import { defineConfig } from 'tsdown'
 
 const prod = Boolean(process.env['PRODUCTION'])
@@ -30,7 +30,7 @@ export default defineConfig({
       '@lezer/common',
       '@lezer/highlight',
       '@lezer/lr',
-      ...builtins
+      ...builtinModules
     ]
   }
 })


### PR DESCRIPTION
## Summary
- Updated readme to point to correct `pnpm check` script.
- Pin `obsidian` dev dep from `latest` to `1.12.3`. Clears Dependabot issue №2.
- Bump `package.json` version from `1.3.0` to `1.3.2` to match `manifest.json`.