### PR TITLE
dead code cleanup and DRY fixes

### DIFF
--- a/src/components/Notifier.ts
+++ b/src/components/Notifier.ts
@@ -2,7 +2,7 @@ import { Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Project } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
-import { isTerminalStatus } from '../utils'
+import { isTerminalStatus, todayMidnight } from '../utils'
 
 const CHECK_INTERVAL_MS = 60 * 60 * 1000 // check every hour
 
@@ -31,8 +31,7 @@ export class Notifier {
     if (!this.plugin.settings.notificationsEnabled) return
 
     const leadDays = this.plugin.settings.notificationLeadDays
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
+    const today = todayMidnight()
     const thresholdMs = today.getTime() + leadDays * 86400_000
 
     let projects: Project[]

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,8 +89,7 @@ export default class PMPlugin extends Plugin {
       callback: () => {
         openProjectModal(this, {
           onSave: async (project) => {
-            const file = this.app.vault.getAbstractFileByPath(project.filePath)
-            if (file instanceof TFile) await this.openProjectFile(file)
+            await this.openProjectByPath(project.filePath)
           }
         })
       }
@@ -198,6 +197,11 @@ export default class PMPlugin extends Plugin {
     await this.app.workspace.revealLeaf(leaf)
   }
 
+  async openProjectByPath(path: string): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(path)
+    if (file instanceof TFile) await this.openProjectFile(file)
+  }
+
   showNotice(msg: string, duration = 3000): void {
     new Notice(msg, duration)
   }
@@ -235,10 +239,7 @@ export default class PMPlugin extends Plugin {
       parentId,
       onSave: async () => {
         await this.store.saveProject(project)
-        const pFile = this.app.vault.getAbstractFileByPath(project.filePath)
-        if (pFile instanceof TFile) {
-          await this.openProjectFile(pFile)
-        }
+        await this.openProjectByPath(project.filePath)
       }
     })
   }
@@ -260,10 +261,7 @@ export default class PMPlugin extends Plugin {
     if (activeProject) {
       const project = activeProject
       const onImportComplete = async () => {
-        const pFile = this.app.vault.getAbstractFileByPath(project.filePath)
-        if (pFile instanceof TFile) {
-          await this.openProjectFile(pFile)
-        }
+        await this.openProjectByPath(project.filePath)
       }
       openImportModal(this, activeProject, onImportComplete)
       return
@@ -278,10 +276,7 @@ export default class PMPlugin extends Plugin {
 
     openProjectPicker(this, projects, (project) => {
       const onImportComplete = async () => {
-        const pFile = this.app.vault.getAbstractFileByPath(project.filePath)
-        if (pFile instanceof TFile) {
-          await this.openProjectFile(pFile)
-        }
+        await this.openProjectByPath(project.filePath)
       }
       openImportModal(this, project, onImportComplete)
     })

--- a/src/modals/TimeTrackingPanel.ts
+++ b/src/modals/TimeTrackingPanel.ts
@@ -1,5 +1,6 @@
 import type { Task } from '../types'
 import { totalLoggedHours } from '../store/TaskTreeOps'
+import { toIsoDate } from '../utils'
 
 /**
  * Renders the time tracking section (estimate, progress bar, log entries)
@@ -81,7 +82,7 @@ export function renderTimeTrackingPanel(container: HTMLElement, task: Task): voi
   addLogBtn.addEventListener('click', () => {
     if (!task.timeLogs) task.timeLogs = []
     task.timeLogs.push({
-      date: new Date().toISOString().slice(0, 10),
+      date: toIsoDate(new Date()),
       hours: 0,
       note: ''
     })

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,5 +17,4 @@ export {
 } from './TaskTreeOps'
 export type { FlatTask } from './TaskTreeOps'
 export { computeSchedule, wouldCreateCycle } from './Scheduler'
-export type { SchedulePatch, ScheduleResult } from './Scheduler'
 export { archiveTask, unarchiveTask } from './ArchiveOps'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { COLOR_ACCENT } from './constants'
+import { toIsoDate } from './utils'
 
 export type TaskStatus = string
 export type TaskPriority = 'critical' | 'high' | 'medium' | 'low'
@@ -164,7 +165,7 @@ export function makeTask(overrides: Partial<Task> = {}): Task {
     type: 'task',
     status: 'todo',
     priority: 'medium',
-    start: new Date().toISOString().slice(0, 10),
+    start: toIsoDate(new Date()),
     due: '',
     progress: 0,
     assignees: [],

--- a/src/ui/FormField.ts
+++ b/src/ui/FormField.ts
@@ -42,16 +42,6 @@ export function renderChipList(
 }
 
 /**
- * Render a date input field.
- */
-export function renderDateInput(cls: string, value: string, onChange: (value: string) => void): HTMLInputElement {
-  const input = createEl('input', { type: 'date', cls })
-  input.value = value
-  input.addEventListener('change', () => onChange(input.value))
-  return input
-}
-
-/**
  * Render a progress slider with label.
  */
 export function renderProgressSlider(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,16 +59,6 @@ export function isTaskOverdue(task: Task, statuses: StatusConfig[]): boolean {
   return dueDate < todayMidnight() && !isTerminalStatus(task.status, statuses)
 }
 
-/** Is a task due within `days` days from today? (not overdue, not terminal) */
-export function isTaskDueSoon(task: Task, days: number, statuses: StatusConfig[]): boolean {
-  if (!task.due) return false
-  if (isTerminalStatus(task.status, statuses)) return false
-  const today = todayMidnight()
-  const dueDate = new Date(task.due)
-  dueDate.setHours(0, 0, 0, 0)
-  return dueDate >= today && dueDate.getTime() <= today.getTime() + days * 86400_000
-}
-
 /** Safely convert a custom-field value to a display string.
  *  Arrays are joined with ", "; objects fall back to '' to avoid [object Object]. */
 export function stringifyCustomValue(val: unknown): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,12 @@ export function todayMidnight(): Date {
   return d
 }
 
+// TODO: formats in UTC, so "today" rolls over in the evening for users
+// west of UTC. Switch to local-time assembly (getFullYear/getMonth/getDate).
+export function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
 /** Is a status marked as terminal (complete) in the config? */
 export function isTerminalStatus(status: string, statuses: StatusConfig[]): boolean {
   const cfg = statuses.find((s) => s.id === status)

--- a/src/views/gantt/GanttRenderer.ts
+++ b/src/views/gantt/GanttRenderer.ts
@@ -3,7 +3,7 @@ import type { Project } from '../../types'
 import type { FlatTask } from '../../store/TaskTreeOps'
 import type { TimelineCfg } from './TimelineConfig'
 import { ROW_HEIGHT, HEADER_HEIGHT, dateToX } from './TimelineConfig'
-import { svgEl } from '../../utils'
+import { svgEl, todayMidnight } from '../../utils'
 import type { DragState } from './GanttDragHandler'
 import type { LinkState } from './GanttLinkHandler'
 
@@ -87,8 +87,7 @@ export function renderGridLines(ctx: RendererContext, totalRows: number): void {
 // ─── Today line ────────────────────────────────────────────────────────────
 
 export function renderTodayLine(ctx: RendererContext, svgHeight: number): void {
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayMidnight()
   const x = dateToX(ctx.cfg, today)
   if (x < 0 || x > ctx.cfg.totalWidth) return
 

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -17,7 +17,7 @@ import {
   renderDependencyArrows,
   renderMilestoneLabels
 } from './GanttRenderer'
-import { svgEl } from '../../utils'
+import { svgEl, todayMidnight } from '../../utils'
 import type { RendererContext } from './GanttRenderer'
 import { renderTaskLabel } from './TaskLabelRenderer'
 
@@ -299,8 +299,7 @@ export class GanttView implements SubView {
 
   private scrollToToday(): void {
     if (!this.scrollEl) return
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
+    const today = todayMidnight()
     const x = dateToX(this.cfg, today)
     const center = x - this.scrollEl.clientWidth / 2
     this.scrollEl.scrollLeft = Math.max(0, center)

--- a/src/views/gantt/TimelineConfig.ts
+++ b/src/views/gantt/TimelineConfig.ts
@@ -151,19 +151,3 @@ export function getWeekNumber(d: Date): number {
   const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
   return Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
 }
-
-export function lighten(hex: string, amount: number): string {
-  return adjustColor(hex, amount)
-}
-
-export function darken(hex: string, amount: number): string {
-  return adjustColor(hex, -amount)
-}
-
-function adjustColor(hex: string, amount: number): string {
-  const num = parseInt(hex.replace('#', ''), 16)
-  const r = Math.min(255, Math.max(0, Math.round(((num >> 16) & 0xff) + 255 * amount)))
-  const g = Math.min(255, Math.max(0, Math.round(((num >> 8) & 0xff) + 255 * amount)))
-  const b = Math.min(255, Math.max(0, Math.round((num & 0xff) + 255 * amount)))
-  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
-}

--- a/src/views/gantt/TimelineConfig.ts
+++ b/src/views/gantt/TimelineConfig.ts
@@ -1,5 +1,6 @@
 import type { Task, GanttGranularity } from '../../types'
 import { flattenTasks } from '../../store/TaskTreeOps'
+import { todayMidnight } from '../../utils'
 
 export const DAY_MS = 86400_000
 export const ROW_HEIGHT = 44
@@ -33,8 +34,7 @@ export function buildTimelineConfig(tasks: Task[], granularity: GanttGranularity
     if (t.due) dates.push(new Date(t.due))
   }
 
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayMidnight()
   dates.push(today)
 
   let startDate = dates.length ? new Date(Math.min(...dates.map((d) => d.getTime()))) : today

--- a/src/views/table/BulkActionBar.ts
+++ b/src/views/table/BulkActionBar.ts
@@ -1,7 +1,7 @@
 import { Menu } from 'obsidian'
 import type { Task, TaskStatus, TaskPriority } from '../../types'
 import { findTask, flattenTasks, collectAllAssignees, collectAllTags } from '../../store'
-import { formatBadgeText } from '../../utils'
+import { formatBadgeText, toIsoDate } from '../../utils'
 import { promptText } from '../../ui/ModalFactory'
 import { TaskPickerModal } from '../../modals/PickerModals'
 import type { TableContext } from './TableRenderer'
@@ -141,29 +141,30 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   dueBtn.addEventListener('click', (e) => {
     const menu = new Menu()
     const today = new Date()
-    const fmt = (d: Date) => d.toISOString().slice(0, 10)
     const addDays = (days: number) => {
       const d = new Date(today)
       d.setDate(d.getDate() + days)
       return d
     }
     menu.addItem((item) =>
-      item.setTitle(`Today (${fmt(today)})`).onClick(() => onAction({ type: 'set-due-date', due: fmt(today) }))
+      item
+        .setTitle(`Today (${toIsoDate(today)})`)
+        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(today) }))
     )
     menu.addItem((item) =>
       item
-        .setTitle(`Tomorrow (${fmt(addDays(1))})`)
-        .onClick(() => onAction({ type: 'set-due-date', due: fmt(addDays(1)) }))
+        .setTitle(`Tomorrow (${toIsoDate(addDays(1))})`)
+        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(addDays(1)) }))
     )
     menu.addItem((item) =>
       item
-        .setTitle(`In 1 week (${fmt(addDays(7))})`)
-        .onClick(() => onAction({ type: 'set-due-date', due: fmt(addDays(7)) }))
+        .setTitle(`In 1 week (${toIsoDate(addDays(7))})`)
+        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(addDays(7)) }))
     )
     menu.addItem((item) =>
       item
-        .setTitle(`In 2 weeks (${fmt(addDays(14))})`)
-        .onClick(() => onAction({ type: 'set-due-date', due: fmt(addDays(14)) }))
+        .setTitle(`In 2 weeks (${toIsoDate(addDays(14))})`)
+        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(addDays(14)) }))
     )
     menu.addSeparator()
     menu.addItem((item) =>

--- a/src/views/table/TableFilters.ts
+++ b/src/views/table/TableFilters.ts
@@ -1,7 +1,7 @@
 import type { Task, FilterState, TaskPriority, DueDateFilter, StatusConfig } from '../../types'
 import type { FlatTask } from '../../store/TaskTreeOps'
 import type { TableState } from './TableRenderer'
-import { isTerminalStatus, statusSortOrder } from '../../utils'
+import { isTerminalStatus, statusSortOrder, todayMidnight } from '../../utils'
 
 export function isFilterActive(filter: FilterState): boolean {
   return !!(
@@ -43,8 +43,7 @@ export function applyFilters(flat: FlatTask[], filter: FilterState, statuses: St
 }
 
 function matchDueDateFilter(task: Task, filter: DueDateFilter, statuses: StatusConfig[] = []): boolean {
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayMidnight()
 
   switch (filter) {
     case 'no-date':

--- a/src/views/table/TableView.ts
+++ b/src/views/table/TableView.ts
@@ -15,6 +15,8 @@ import { updateSelectAllCheckbox } from './TableRow'
 import { renderBulkActionBar } from './BulkActionBar'
 import type { BulkAction } from './BulkActionBar'
 
+const taskCount = (n: number) => `${n} task${n === 1 ? '' : 's'}`
+
 export interface TableViewState {
   filter: FilterState
   sortKey: SortKey
@@ -156,31 +158,26 @@ export class TableView implements SubView {
           break
         case 'set-parent':
           await this.plugin.store.moveTasks(this.project, ids, action.parentId)
-          new Notice(`Moved ${ids.length} task${ids.length > 1 ? 's' : ''} under new parent`)
+          new Notice(`Moved ${taskCount(ids.length)} under new parent`)
           break
         case 'remove-parent':
           await this.plugin.store.moveTasks(this.project, ids, null)
-          new Notice(`Moved ${ids.length} task${ids.length > 1 ? 's' : ''} to top level`)
+          new Notice(`Moved ${taskCount(ids.length)} to top level`)
           break
         case 'archive':
           for (const id of ids) {
             await this.plugin.store.archiveTask(this.project, id)
           }
-          new Notice(`Archived ${ids.length} task${ids.length > 1 ? 's' : ''}`)
+          new Notice(`Archived ${taskCount(ids.length)}`)
           break
         case 'unarchive':
           for (const id of ids) {
             await this.plugin.store.unarchiveTask(this.project, id)
           }
-          new Notice(`Unarchived ${ids.length} task${ids.length > 1 ? 's' : ''}`)
+          new Notice(`Unarchived ${taskCount(ids.length)}`)
           break
         case 'delete':
-          if (
-            !(await confirmDialog(
-              this.plugin.app,
-              `Delete ${ids.length} task${ids.length > 1 ? 's' : ''}? This cannot be undone.`
-            ))
-          ) {
+          if (!(await confirmDialog(this.plugin.app, `Delete ${taskCount(ids.length)}? This cannot be undone.`))) {
             return
           }
           await this.plugin.store.deleteTasks(this.project, ids)


### PR DESCRIPTION
- Delete unused: `isTaskDueSoon`, `renderDateInput`, `lighten`/`darken`/`adjustColor`, and the `SchedulePatch`/`ScheduleResult` re-export.
- `todayMidnight()` replaces 5 inline copies.
- `openProjectByPath()` in `main.ts` replaces 3 copies of the `getAbstractFileByPath` + `instanceof TFile` dance.
- `toIsoDate(d)` replaces 3 inline `.toISOString().slice(0, 10)`. Carries a TODO for the UTC-vs-local off-by-one.
- File-local `taskCount(n)` in `TableView` replaces 5 pluralize ternaries.