### PR TITLE
migrate task dates to temporal

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "obsidian": "1.12.3",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
+    "temporal-polyfill": "0.3.2",
     "tsdown": "0.21.9",
     "typescript": "6.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       oxlint:
         specifier: 1.61.0
         version: 1.61.0
+      temporal-polyfill:
+        specifier: 0.3.2
+        version: 0.3.2
       tsdown:
         specifier: 0.21.9
         version: 0.21.9(typescript@6.0.2)
@@ -1774,6 +1777,12 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  temporal-polyfill@0.3.2:
+    resolution: {integrity: sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==}
+
+  temporal-spec@0.3.1:
+    resolution: {integrity: sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -3840,6 +3849,12 @@ snapshots:
       tslib: 2.8.1
 
   tapable@2.3.2: {}
+
+  temporal-polyfill@0.3.2:
+    dependencies:
+      temporal-spec: 0.3.1
+
+  temporal-spec@0.3.1: {}
 
   tinyexec@1.1.1: {}
 

--- a/src/components/Notifier.ts
+++ b/src/components/Notifier.ts
@@ -2,7 +2,8 @@ import { Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Project } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
-import { isTerminalStatus, todayMidnight } from '../utils'
+import { isTerminalStatus } from '../utils'
+import { Temporal, today, parsePlainDate } from '../dates'
 
 const CHECK_INTERVAL_MS = 60 * 60 * 1000 // check every hour
 
@@ -31,8 +32,8 @@ export class Notifier {
     if (!this.plugin.settings.notificationsEnabled) return
 
     const leadDays = this.plugin.settings.notificationLeadDays
-    const today = todayMidnight()
-    const thresholdMs = today.getTime() + leadDays * 86400_000
+    const now = today()
+    const threshold = now.add({ days: leadDays })
 
     let projects: Project[]
     try {
@@ -44,24 +45,23 @@ export class Notifier {
     for (const project of projects) {
       const flat = flattenTasks(project.tasks)
       for (const { task } of flat) {
-        if (!task.due) continue
+        const due = parsePlainDate(task.due)
+        if (!due) continue
         if (isTerminalStatus(task.status, this.plugin.settings.statuses)) continue
 
-        const dueDate = new Date(task.due)
-        dueDate.setHours(0, 0, 0, 0)
-
-        const isOverdue = dueDate < today
-        const isDueSoon = dueDate.getTime() <= thresholdMs && dueDate >= today
+        const cmpToToday = Temporal.PlainDate.compare(due, now)
+        const isOverdue = cmpToToday < 0
+        const isDueSoon = cmpToToday >= 0 && Temporal.PlainDate.compare(due, threshold) <= 0
 
         const notifKey = `${task.id}-${task.due}`
 
         if (isOverdue && !this.notifiedIds.has(notifKey + '-overdue')) {
           this.notifiedIds.add(notifKey + '-overdue')
-          const daysAgo = Math.round((today.getTime() - dueDate.getTime()) / 86400_000)
+          const daysAgo = now.since(due, { largestUnit: 'days' }).days
           new Notice(`⚠️ Overdue: "${task.title}" in ${project.title} was due ${daysAgo}d ago`, 8000)
         } else if (isDueSoon && !this.notifiedIds.has(notifKey + '-soon')) {
           this.notifiedIds.add(notifKey + '-soon')
-          const daysLeft = Math.round((dueDate.getTime() - today.getTime()) / 86400_000)
+          const daysLeft = due.since(now, { largestUnit: 'days' }).days
           const msg =
             daysLeft === 0
               ? `📅 Due today: "${task.title}" in ${project.title}`

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -1,0 +1,18 @@
+import { Temporal } from 'temporal-polyfill'
+
+export { Temporal }
+
+/** Today as a PlainDate in the user's local timezone. */
+export function today(): Temporal.PlainDate {
+  return Temporal.Now.plainDateISO()
+}
+
+/** Parse a YYYY-MM-DD field; returns null for empty/invalid strings. */
+export function parsePlainDate(s: string): Temporal.PlainDate | null {
+  if (!s) return null
+  try {
+    return Temporal.PlainDate.from(s)
+  } catch {
+    return null
+  }
+}

--- a/src/modals/TimeTrackingPanel.ts
+++ b/src/modals/TimeTrackingPanel.ts
@@ -1,6 +1,6 @@
 import type { Task } from '../types'
 import { totalLoggedHours } from '../store/TaskTreeOps'
-import { toIsoDate } from '../utils'
+import { today } from '../dates'
 
 /**
  * Renders the time tracking section (estimate, progress bar, log entries)
@@ -82,7 +82,7 @@ export function renderTimeTrackingPanel(container: HTMLElement, task: Task): voi
   addLogBtn.addEventListener('click', () => {
     if (!task.timeLogs) task.timeLogs = []
     task.timeLogs.push({
-      date: toIsoDate(new Date()),
+      date: today().toString(),
       hours: 0,
       note: ''
     })

--- a/src/store/Scheduler.ts
+++ b/src/store/Scheduler.ts
@@ -1,6 +1,7 @@
 import { Task, StatusConfig } from '../types'
 import { flattenTasks } from './TaskTreeOps'
 import { isTerminalStatus } from '../utils'
+import { Temporal } from '../dates'
 
 /* ── Types ─────────────────────────────────────────────────────── */
 
@@ -19,15 +20,12 @@ export interface ScheduleResult {
 
 /** Number of calendar days between two YYYY-MM-DD strings. */
 export function daysBetween(a: string, b: string): number {
-  const msPerDay = 86_400_000
-  return Math.round((new Date(b + 'T00:00:00Z').getTime() - new Date(a + 'T00:00:00Z').getTime()) / msPerDay)
+  return Temporal.PlainDate.from(b).since(Temporal.PlainDate.from(a), { largestUnit: 'days' }).days
 }
 
 /** Add `n` days to a YYYY-MM-DD string. */
 export function addDays(date: string, n: number): string {
-  const d = new Date(date + 'T00:00:00Z')
-  d.setUTCDate(d.getUTCDate() + n)
-  return d.toISOString().slice(0, 10)
+  return Temporal.PlainDate.from(date).add({ days: n }).toString()
 }
 
 /* ── Cycle detection helper (for dependency-add UI) ───────────── */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { COLOR_ACCENT } from './constants'
-import { toIsoDate } from './utils'
+import { today } from './dates'
 
 export type TaskStatus = string
 export type TaskPriority = 'critical' | 'high' | 'medium' | 'low'
@@ -165,7 +165,7 @@ export function makeTask(overrides: Partial<Task> = {}): Task {
     type: 'task',
     status: 'todo',
     priority: 'medium',
-    start: toIsoDate(new Date()),
+    start: today().toString(),
     due: '',
     progress: 0,
     assignees: [],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { Notice } from 'obsidian'
 import type { Task, StatusConfig, PriorityConfig, TaskPriority } from './types'
+import { today, parsePlainDate, Temporal } from './dates'
 
 /** Deterministic HSL color from a string (e.g. assignee name) */
 export function stringToColor(s: string): string {
@@ -22,17 +23,14 @@ export function formatDateLong(iso: string): string {
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' })
 }
 
-/** Today at midnight (00:00:00.000) */
+/**
+ * Today at local midnight as a JS Date. Use only for Gantt pixel math;
+ * domain code should prefer `today()` from ./dates (Temporal.PlainDate).
+ */
 export function todayMidnight(): Date {
   const d = new Date()
   d.setHours(0, 0, 0, 0)
   return d
-}
-
-// TODO: formats in UTC, so "today" rolls over in the evening for users
-// west of UTC. Switch to local-time assembly (getFullYear/getMonth/getDate).
-export function toIsoDate(d: Date): string {
-  return d.toISOString().slice(0, 10)
 }
 
 /** Is a status marked as terminal (complete) in the config? */
@@ -60,9 +58,9 @@ export function statusSortOrder(status: string, statuses: StatusConfig[]): numbe
 
 /** Is a task overdue? (past due, not in a terminal status) */
 export function isTaskOverdue(task: Task, statuses: StatusConfig[]): boolean {
-  if (!task.due) return false
-  const dueDate = new Date(task.due)
-  return dueDate < todayMidnight() && !isTerminalStatus(task.status, statuses)
+  const due = parsePlainDate(task.due)
+  if (!due) return false
+  return Temporal.PlainDate.compare(due, today()) < 0 && !isTerminalStatus(task.status, statuses)
 }
 
 /** Safely convert a custom-field value to a display string.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,16 +23,6 @@ export function formatDateLong(iso: string): string {
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' })
 }
 
-/**
- * Today at local midnight as a JS Date. Use only for Gantt pixel math;
- * domain code should prefer `today()` from ./dates (Temporal.PlainDate).
- */
-export function todayMidnight(): Date {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  return d
-}
-
 /** Is a status marked as terminal (complete) in the config? */
 export function isTerminalStatus(status: string, statuses: StatusConfig[]): boolean {
   const cfg = statuses.find((s) => s.id === status)

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -283,7 +283,7 @@ export class ProjectView extends ItemView {
       activeDocument.activeElement instanceof HTMLElement && activeDocument.activeElement.matches('.pm-quick-add-input')
 
     // Save Gantt scroll position and label width before destroying the old view
-    let savedGanttScroll: { top: number; anchorDate: Date } | null = null
+    let savedGanttScroll: ReturnType<GanttView['getScrollPosition']> | null = null
     let savedGanttLabelWidth: number | null = null
     if (this.currentView === 'gantt' && this.subview instanceof GanttView) {
       savedGanttScroll = this.subview.getScrollPosition()

--- a/src/views/gantt/GanttDragHandler.ts
+++ b/src/views/gantt/GanttDragHandler.ts
@@ -3,7 +3,7 @@ import type PMPlugin from '../../main'
 import type { Project, Task } from '../../types'
 import { safeAsync } from '../../utils'
 import type { TimelineCfg } from './TimelineConfig'
-import { xToDate, dateToIso, getSnapPoints, snapX } from './TimelineConfig'
+import { xToDate, getSnapPoints, snapX } from './TimelineConfig'
 
 export interface DragState {
   isDragging: boolean
@@ -101,11 +101,9 @@ export function attachDragHandle(
 
       const patch: Partial<Task> = {}
       if (drag.dragSide === 'left') {
-        patch.start = dateToIso(xToDate(cfg, snappedX))
+        patch.start = xToDate(cfg, snappedX).toString()
       } else {
-        const endD = xToDate(cfg, snappedRight)
-        endD.setDate(endD.getDate() - 1)
-        patch.due = dateToIso(endD)
+        patch.due = xToDate(cfg, snappedRight).subtract({ days: 1 }).toString()
       }
       try {
         await plugin.store.updateTask(project, taskId, patch)
@@ -218,12 +216,11 @@ export function attachBarMove(
       const snappedRight = snapX(snappedX + drag.dragInitialW, snapPoints, snapThreshold)
 
       const newStart = xToDate(cfg, snappedX)
-      const newEnd = xToDate(cfg, snappedRight)
-      newEnd.setDate(newEnd.getDate() - 1)
+      const newEnd = xToDate(cfg, snappedRight).subtract({ days: 1 })
 
       const patch: Partial<Task> = {
-        start: dateToIso(newStart),
-        due: dateToIso(newEnd)
+        start: newStart.toString(),
+        due: newEnd.toString()
       }
       try {
         await plugin.store.updateTask(project, taskId, patch)

--- a/src/views/gantt/GanttHeaderRenderer.ts
+++ b/src/views/gantt/GanttHeaderRenderer.ts
@@ -1,24 +1,23 @@
 import type { RendererContext } from './GanttRenderer'
 import { HEADER_HEIGHT, dateToX, getWeekNumber } from './TimelineConfig'
 import { svgEl } from '../../utils'
+import { Temporal } from '../../dates'
 
 import type { GanttWeekLabel } from '../../types'
 
 // ─── Week label formatting ────────────────────────────────────────────────
 
-function formatDateRange(weekStart: Date, days: number): string {
-  const end = new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate() + days - 1)
-  const startDay = weekStart.getDate()
-  const endDay = end.getDate()
-  const startMonth = weekStart.toLocaleDateString(undefined, { month: 'short' })
-  if (weekStart.getMonth() === end.getMonth()) {
-    return `${startMonth} ${startDay}\u2013${endDay}`
+function formatDateRange(weekStart: Temporal.PlainDate, days: number): string {
+  const end = weekStart.add({ days: days - 1 })
+  const startMonth = weekStart.toLocaleString(undefined, { month: 'short' })
+  if (weekStart.month === end.month) {
+    return `${startMonth} ${weekStart.day}–${end.day}`
   }
-  const endMonth = end.toLocaleDateString(undefined, { month: 'short' })
-  return `${startMonth} ${startDay} \u2013 ${endMonth} ${endDay}`
+  const endMonth = end.toLocaleString(undefined, { month: 'short' })
+  return `${startMonth} ${weekStart.day} – ${endMonth} ${end.day}`
 }
 
-function formatWeekLabel(weekStart: Date, days: number, weekNum: number, mode: GanttWeekLabel): string {
+function formatWeekLabel(weekStart: Temporal.PlainDate, days: number, weekNum: number, mode: GanttWeekLabel): string {
   if (mode === 'weekNumber') return `W${weekNum}`
   const range = formatDateRange(weekStart, days)
   if (mode === 'dateRange') return range
@@ -53,9 +52,9 @@ function renderDayHeader(g: SVGGElement, ctx: RendererContext): void {
   const { startDate, totalDays, dayWidth } = ctx.cfg
   renderMonthBands(g, 0, 24, ctx)
   for (let i = 0; i < totalDays; i++) {
-    const d = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + i)
+    const d = startDate.add({ days: i })
     const x = i * dayWidth
-    const isWeekend = d.getDay() === 0 || d.getDay() === 6
+    const isWeekend = d.dayOfWeek === 6 || d.dayOfWeek === 7
     if (isWeekend) {
       g.appendChild(
         svgEl('rect', {
@@ -73,7 +72,7 @@ function renderDayHeader(g: SVGGElement, ctx: RendererContext): void {
         y: 42,
         class: 'pm-gantt-header-day'
       })
-      text.textContent = String(d.getDate())
+      text.textContent = String(d.day)
       g.appendChild(text)
     }
   }
@@ -84,8 +83,7 @@ function renderWeekHeader(g: SVGGElement, ctx: RendererContext): void {
   renderMonthBands(g, 0, 24, ctx)
 
   // Align to actual Mondays so header ticks match grid lines
-  const dow = startDate.getDay() // 0=Sun … 6=Sat
-  const offsetToMonday = dow === 1 ? 0 : dow === 0 ? 1 : 8 - dow
+  const offsetToMonday = startDate.dayOfWeek === 1 ? 0 : 8 - startDate.dayOfWeek
 
   const labelMode = ctx.plugin.settings.ganttWeekLabel
 
@@ -105,7 +103,7 @@ function renderWeekHeader(g: SVGGElement, ctx: RendererContext): void {
   // Full weeks from each Monday
   let i = offsetToMonday
   while (i < totalDays) {
-    const d = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + i)
+    const d = startDate.add({ days: i })
     const weekNum = getWeekNumber(d)
     const x = i * dayWidth
     const daysInWeek = Math.min(7, totalDays - i)
@@ -131,12 +129,10 @@ function renderWeekHeader(g: SVGGElement, ctx: RendererContext): void {
 }
 
 function renderMonthHeader(g: SVGGElement, ctx: RendererContext): void {
-  const { startDate } = ctx.cfg
   renderYearBands(g, 0, 24, ctx)
-  const date = new Date(startDate)
-  while (date < ctx.cfg.endDate) {
-    const monthStart = new Date(date.getFullYear(), date.getMonth(), 1)
-    const nextMonthStart = new Date(date.getFullYear(), date.getMonth() + 1, 1)
+  let monthStart = ctx.cfg.startDate.with({ day: 1 })
+  while (Temporal.PlainDate.compare(monthStart, ctx.cfg.endDate) < 0) {
+    const nextMonthStart = monthStart.add({ months: 1 })
     const x1 = Math.max(0, dateToX(ctx.cfg, monthStart))
     const x2 = Math.min(ctx.cfg.totalWidth, dateToX(ctx.cfg, nextMonthStart))
     const w = x2 - x1
@@ -145,7 +141,7 @@ function renderMonthHeader(g: SVGGElement, ctx: RendererContext): void {
       y: 44,
       class: 'pm-gantt-header-month'
     })
-    text.textContent = monthStart.toLocaleDateString(undefined, { month: 'short' })
+    text.textContent = monthStart.toLocaleString(undefined, { month: 'short' })
     g.appendChild(text)
     g.appendChild(
       svgEl('line', {
@@ -156,17 +152,21 @@ function renderMonthHeader(g: SVGGElement, ctx: RendererContext): void {
         class: 'pm-gantt-header-tick'
       })
     )
-    date.setMonth(date.getMonth() + 1)
+    monthStart = nextMonthStart
   }
 }
 
 function renderQuarterHeader(g: SVGGElement, ctx: RendererContext): void {
-  const { startDate } = ctx.cfg
   renderYearBands(g, 0, 24, ctx)
-  const date = new Date(startDate.getFullYear(), Math.floor(startDate.getMonth() / 3) * 3, 1)
-  while (date < ctx.cfg.endDate) {
-    const q = Math.floor(date.getMonth() / 3) + 1
-    const nextQStart = new Date(date.getFullYear(), date.getMonth() + 3, 1)
+  const { startDate } = ctx.cfg
+  let date = Temporal.PlainDate.from({
+    year: startDate.year,
+    month: Math.floor((startDate.month - 1) / 3) * 3 + 1,
+    day: 1
+  })
+  while (Temporal.PlainDate.compare(date, ctx.cfg.endDate) < 0) {
+    const q = Math.floor((date.month - 1) / 3) + 1
+    const nextQStart = date.add({ months: 3 })
     const x1 = Math.max(0, dateToX(ctx.cfg, date))
     const x2 = Math.min(ctx.cfg.totalWidth, dateToX(ctx.cfg, nextQStart))
     const text = svgEl('text', {
@@ -174,17 +174,16 @@ function renderQuarterHeader(g: SVGGElement, ctx: RendererContext): void {
       y: 44,
       class: 'pm-gantt-header-quarter'
     })
-    text.textContent = `Q${q} ${date.getFullYear()}`
+    text.textContent = `Q${q} ${date.year}`
     g.appendChild(text)
-    date.setMonth(date.getMonth() + 3)
+    date = nextQStart
   }
 }
 
 function renderMonthBands(g: SVGGElement, y: number, h: number, ctx: RendererContext): void {
-  const date = new Date(ctx.cfg.startDate)
-  while (date < ctx.cfg.endDate) {
-    const monthStart = new Date(date.getFullYear(), date.getMonth(), 1)
-    const nextMonthStart = new Date(date.getFullYear(), date.getMonth() + 1, 1)
+  let monthStart = ctx.cfg.startDate.with({ day: 1 })
+  while (Temporal.PlainDate.compare(monthStart, ctx.cfg.endDate) < 0) {
+    const nextMonthStart = monthStart.add({ months: 1 })
     const x1 = Math.max(0, dateToX(ctx.cfg, monthStart))
     const x2 = Math.min(ctx.cfg.totalWidth, dateToX(ctx.cfg, nextMonthStart))
     const w = x2 - x1
@@ -194,7 +193,7 @@ function renderMonthBands(g: SVGGElement, y: number, h: number, ctx: RendererCon
         y,
         width: w,
         height: h,
-        class: date.getMonth() % 2 === 0 ? 'pm-gantt-band-even' : 'pm-gantt-band-odd'
+        class: (monthStart.month - 1) % 2 === 0 ? 'pm-gantt-band-even' : 'pm-gantt-band-odd'
       })
     )
     const text = svgEl('text', {
@@ -202,16 +201,16 @@ function renderMonthBands(g: SVGGElement, y: number, h: number, ctx: RendererCon
       y: y + h - 6,
       class: 'pm-gantt-header-month-top'
     })
-    text.textContent = monthStart.toLocaleDateString(undefined, { month: 'short', year: '2-digit' })
+    text.textContent = monthStart.toLocaleString(undefined, { month: 'short', year: '2-digit' })
     g.appendChild(text)
-    date.setMonth(date.getMonth() + 1)
+    monthStart = nextMonthStart
   }
 }
 
 function renderYearBands(g: SVGGElement, y: number, h: number, ctx: RendererContext): void {
-  const date = new Date(ctx.cfg.startDate.getFullYear(), 0, 1)
-  while (date < ctx.cfg.endDate) {
-    const yearEnd = new Date(date.getFullYear() + 1, 0, 1)
+  let date = Temporal.PlainDate.from({ year: ctx.cfg.startDate.year, month: 1, day: 1 })
+  while (Temporal.PlainDate.compare(date, ctx.cfg.endDate) < 0) {
+    const yearEnd = date.add({ years: 1 })
     const x1 = Math.max(0, dateToX(ctx.cfg, date))
     const x2 = Math.min(ctx.cfg.totalWidth, dateToX(ctx.cfg, yearEnd))
     g.appendChild(
@@ -220,7 +219,7 @@ function renderYearBands(g: SVGGElement, y: number, h: number, ctx: RendererCont
         y,
         width: x2 - x1,
         height: h,
-        class: date.getFullYear() % 2 === 0 ? 'pm-gantt-band-even' : 'pm-gantt-band-odd'
+        class: date.year % 2 === 0 ? 'pm-gantt-band-even' : 'pm-gantt-band-odd'
       })
     )
     const text = svgEl('text', {
@@ -228,8 +227,8 @@ function renderYearBands(g: SVGGElement, y: number, h: number, ctx: RendererCont
       y: y + h - 6,
       class: 'pm-gantt-header-year'
     })
-    text.textContent = String(date.getFullYear())
+    text.textContent = String(date.year)
     g.appendChild(text)
-    date.setFullYear(date.getFullYear() + 1)
+    date = yearEnd
   }
 }

--- a/src/views/gantt/GanttRenderer.ts
+++ b/src/views/gantt/GanttRenderer.ts
@@ -3,7 +3,8 @@ import type { Project } from '../../types'
 import type { FlatTask } from '../../store/TaskTreeOps'
 import type { TimelineCfg } from './TimelineConfig'
 import { ROW_HEIGHT, HEADER_HEIGHT, dateToX } from './TimelineConfig'
-import { svgEl, todayMidnight } from '../../utils'
+import { svgEl } from '../../utils'
+import { today } from '../../dates'
 import type { DragState } from './GanttDragHandler'
 import type { LinkState } from './GanttLinkHandler'
 
@@ -31,11 +32,11 @@ export function renderGridLines(ctx: RendererContext, totalRows: number): void {
   const { startDate, totalDays, dayWidth, granularity } = ctx.cfg
 
   for (let i = 0; i < totalDays; i++) {
-    const d = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + i)
+    const d = startDate.add({ days: i })
     const x = i * dayWidth
-    const isWeekend = d.getDay() === 0 || d.getDay() === 6
-    const isMonday = d.getDay() === 1
-    const isFirst = d.getDate() === 1
+    const isWeekend = d.dayOfWeek === 6 || d.dayOfWeek === 7
+    const isMonday = d.dayOfWeek === 1
+    const isFirst = d.day === 1
 
     if (isWeekend && granularity === 'day') {
       g.appendChild(
@@ -53,7 +54,7 @@ export function renderGridLines(ctx: RendererContext, totalRows: number): void {
       (granularity === 'day' && isMonday) ||
       (granularity === 'week' && isMonday) ||
       (granularity === 'month' && isFirst) ||
-      (granularity === 'quarter' && isFirst && d.getMonth() % 3 === 0)
+      (granularity === 'quarter' && isFirst && (d.month - 1) % 3 === 0)
 
     if (shouldDrawLine) {
       g.appendChild(
@@ -87,8 +88,7 @@ export function renderGridLines(ctx: RendererContext, totalRows: number): void {
 // ─── Today line ────────────────────────────────────────────────────────────
 
 export function renderTodayLine(ctx: RendererContext, svgHeight: number): void {
-  const today = todayMidnight()
-  const x = dateToX(ctx.cfg, today)
+  const x = dateToX(ctx.cfg, today())
   if (x < 0 || x > ctx.cfg.totalWidth) return
 
   const g = svgEl('g', { class: 'pm-gantt-today-group' })

--- a/src/views/gantt/GanttTaskBarRenderer.ts
+++ b/src/views/gantt/GanttTaskBarRenderer.ts
@@ -4,15 +4,14 @@ import { flattenTasks, filterArchived, filterDone } from '../../store/TaskTreeOp
 import { openTaskModal } from '../../ui/ModalFactory'
 import { COLOR_ACCENT } from '../../constants'
 import { svgEl, getStatusConfig, safeAsync } from '../../utils'
+import { parsePlainDate } from '../../dates'
 import {
-  DAY_MS,
   ROW_HEIGHT,
   HEADER_HEIGHT,
   BAR_PADDING,
   BAR_BORDER_RADIUS,
   dateToX,
   xToDate,
-  dateToIso,
   getSnapPoints,
   snapX
 } from './TimelineConfig'
@@ -23,8 +22,8 @@ import type { RendererContext } from './GanttRenderer'
 // ─── Task bars ─────────────────────────────────────────────────────────────
 
 export function renderTaskBar(g: SVGGElement, task: Task, row: number, _depth: number, ctx: RendererContext): void {
-  const startDate = task.start ? new Date(task.start) : null
-  const endDate = task.due ? new Date(task.due) : null
+  const startDate = parsePlainDate(task.start)
+  const endDate = parsePlainDate(task.due)
   if (!startDate && !endDate) {
     renderEmptyRowClickTarget(g, task, row, ctx)
     return
@@ -53,9 +52,10 @@ export function renderTaskBar(g: SVGGElement, task: Task, row: number, _depth: n
     return
   }
 
-  // Normal task bar
+  // Normal task bar. A task with end date E occupies the day E, so the bar
+  // right edge sits at the start of E+1.
   const effectiveStart = startDate ?? endDate!
-  const effectiveEnd = endDate ? new Date(endDate.getTime() + DAY_MS) : new Date(effectiveStart.getTime() + DAY_MS)
+  const effectiveEnd = (endDate ?? effectiveStart).add({ days: 1 })
 
   const x = Math.max(0, dateToX(ctx.cfg, effectiveStart))
   const xEnd = Math.min(ctx.cfg.totalWidth, dateToX(ctx.cfg, effectiveEnd))
@@ -284,8 +284,7 @@ function renderEmptyRowClickTarget(g: SVGGElement, task: Task, row: number, ctx:
       const svgRect = ctx.svgEl.getBoundingClientRect()
       const rawX = e.clientX - svgRect.left
       const snapped = snapX(rawX, snapPoints, snapThreshold)
-      const date = xToDate(ctx.cfg, snapped)
-      const iso = dateToIso(date)
+      const iso = xToDate(ctx.cfg, snapped).toString()
 
       try {
         await ctx.plugin.store.updateTask(ctx.project, task.id, { start: iso, due: iso })
@@ -310,7 +309,7 @@ function renderEmptyRowClickTarget(g: SVGGElement, task: Task, row: number, ctx:
 // ─── Milestone diamond ────────────────────────────────────────────────────
 
 function renderMilestoneDiamond(g: SVGGElement, task: Task, row: number, color: string, ctx: RendererContext): void {
-  const date = task.due ? new Date(task.due) : task.start ? new Date(task.start) : null
+  const date = parsePlainDate(task.due) ?? parsePlainDate(task.start)
   if (!date) return
 
   const cx = dateToX(ctx.cfg, date) + ctx.cfg.dayWidth / 2
@@ -346,7 +345,8 @@ export function renderMilestoneLabels(ctx: RendererContext): void {
   const labelsG = svgEl('g', { class: 'pm-gantt-milestone-labels' })
 
   for (const { task } of milestones) {
-    const date = task.due ? new Date(task.due) : new Date(task.start)
+    const date = parsePlainDate(task.due) ?? parsePlainDate(task.start)
+    if (!date) continue
     const x = dateToX(ctx.cfg, date) + ctx.cfg.dayWidth / 2
     const statusConfig = getStatusConfig(ctx.plugin.settings.statuses, task.status)
     const color = statusConfig?.color ?? COLOR_ACCENT
@@ -403,15 +403,17 @@ export function renderDependencyArrows(ctx: RendererContext): void {
     const toRow = indexMap.get(task.id)
     if (toRow === undefined) continue
     const toY = HEADER_HEIGHT + toRow * ROW_HEIGHT + ROW_HEIGHT / 2
-    const toX = task.start ? dateToX(ctx.cfg, new Date(task.start)) : -1
-    if (toX < 0) continue
+    const taskStart = parsePlainDate(task.start)
+    if (!taskStart) continue
+    const toX = dateToX(ctx.cfg, taskStart)
 
     for (const depId of task.dependencies) {
       const fromRow = indexMap.get(depId)
       if (fromRow === undefined) continue
       const depTask = allFlat.find((f) => f.task.id === depId)?.task
-      if (!depTask?.due) continue
-      const fromX = dateToX(ctx.cfg, new Date(new Date(depTask.due).getTime() + DAY_MS))
+      const depDue = depTask ? parsePlainDate(depTask.due) : null
+      if (!depDue) continue
+      const fromX = dateToX(ctx.cfg, depDue.add({ days: 1 }))
       const fromY = HEADER_HEIGHT + fromRow * ROW_HEIGHT + ROW_HEIGHT / 2
 
       const midX = (fromX + toX) / 2

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -17,7 +17,8 @@ import {
   renderDependencyArrows,
   renderMilestoneLabels
 } from './GanttRenderer'
-import { svgEl, todayMidnight } from '../../utils'
+import { svgEl } from '../../utils'
+import { Temporal, today } from '../../dates'
 import type { RendererContext } from './GanttRenderer'
 import { renderTaskLabel } from './TaskLabelRenderer'
 
@@ -38,7 +39,7 @@ export class GanttView implements SubView {
     this.labelWidth = w
   }
   private cleanupFns: (() => void)[] = []
-  private pendingScroll: { top: number; anchorDate: Date } | null = null
+  private pendingScroll: { top: number; anchorDate: Temporal.PlainDate } | null = null
 
   constructor(
     private container: HTMLElement,
@@ -54,13 +55,13 @@ export class GanttView implements SubView {
     this.cleanupFns = []
   }
 
-  getScrollPosition(): { top: number; anchorDate: Date } {
+  getScrollPosition(): { top: number; anchorDate: Temporal.PlainDate } {
     const top = this.scrollEl?.scrollTop ?? 0
-    const anchorDate = this.scrollEl ? xToDate(this.cfg, this.scrollEl.scrollLeft) : new Date()
+    const anchorDate = this.scrollEl ? xToDate(this.cfg, this.scrollEl.scrollLeft) : today()
     return { top, anchorDate }
   }
 
-  setPendingScroll(pos: { top: number; anchorDate: Date }): void {
+  setPendingScroll(pos: { top: number; anchorDate: Temporal.PlainDate }): void {
     this.pendingScroll = pos
   }
 
@@ -299,8 +300,7 @@ export class GanttView implements SubView {
 
   private scrollToToday(): void {
     if (!this.scrollEl) return
-    const today = todayMidnight()
-    const x = dateToX(this.cfg, today)
+    const x = dateToX(this.cfg, today())
     const center = x - this.scrollEl.clientWidth / 2
     this.scrollEl.scrollLeft = Math.max(0, center)
   }

--- a/src/views/gantt/TimelineConfig.ts
+++ b/src/views/gantt/TimelineConfig.ts
@@ -1,8 +1,7 @@
 import type { Task, GanttGranularity } from '../../types'
 import { flattenTasks } from '../../store/TaskTreeOps'
-import { todayMidnight } from '../../utils'
+import { Temporal, today, parsePlainDate } from '../../dates'
 
-export const DAY_MS = 86400_000
 export const ROW_HEIGHT = 44
 export const HEADER_HEIGHT = 56
 export const LABEL_WIDTH = 280
@@ -17,56 +16,57 @@ export const DAY_WIDTH: Record<GanttGranularity, number> = {
 }
 
 export interface TimelineCfg {
-  startDate: Date
-  endDate: Date
+  startDate: Temporal.PlainDate
+  endDate: Temporal.PlainDate
   dayWidth: number
   granularity: GanttGranularity
   totalDays: number
   totalWidth: number
 }
 
+const MIN_DAYS: Record<GanttGranularity, number> = {
+  day: 30,
+  week: 90,
+  month: 365,
+  quarter: 365
+}
+
 export function buildTimelineConfig(tasks: Task[], granularity: GanttGranularity): TimelineCfg {
   const allTasks = flattenTasks(tasks).map((f) => f.task)
-  const dates: Date[] = []
+  const dates: Temporal.PlainDate[] = []
 
   for (const t of allTasks) {
-    if (t.start) dates.push(new Date(t.start))
-    if (t.due) dates.push(new Date(t.due))
+    const start = parsePlainDate(t.start)
+    const due = parsePlainDate(t.due)
+    if (start) dates.push(start)
+    if (due) dates.push(due)
   }
 
-  const today = todayMidnight()
-  dates.push(today)
+  const now = today()
+  dates.push(now)
 
-  let startDate = dates.length ? new Date(Math.min(...dates.map((d) => d.getTime()))) : today
-  let endDate = dates.length
-    ? new Date(Math.max(...dates.map((d) => d.getTime())))
-    : new Date(today.getTime() + 30 * DAY_MS)
+  let startDate = dates.reduce((min, d) => (Temporal.PlainDate.compare(d, min) < 0 ? d : min), dates[0])
+  let endDate = dates.reduce((max, d) => (Temporal.PlainDate.compare(d, max) > 0 ? d : max), dates[0])
 
   // Add padding
-  startDate = new Date(startDate.getTime() - 7 * DAY_MS)
-  endDate = new Date(endDate.getTime() + 14 * DAY_MS)
+  startDate = startDate.subtract({ days: 7 })
+  endDate = endDate.add({ days: 14 })
 
   // Enforce minimum visible range based on granularity
-  const minDays: Record<GanttGranularity, number> = {
-    day: 30,
-    week: 90,
-    month: 365,
-    quarter: 365
-  }
-  const currentSpan = (endDate.getTime() - startDate.getTime()) / DAY_MS
-  if (currentSpan < minDays[granularity]) {
-    const extra = (minDays[granularity] - currentSpan) / 2
-    startDate = new Date(startDate.getTime() - extra * DAY_MS)
-    endDate = new Date(endDate.getTime() + extra * DAY_MS)
+  const currentSpan = endDate.since(startDate, { largestUnit: 'days' }).days
+  if (currentSpan < MIN_DAYS[granularity]) {
+    const extra = Math.ceil((MIN_DAYS[granularity] - currentSpan) / 2)
+    startDate = startDate.subtract({ days: extra })
+    endDate = endDate.add({ days: extra })
   }
 
   // Snap to month start for cleaner headers
   if (granularity === 'week' || granularity === 'month' || granularity === 'quarter') {
-    startDate.setDate(1)
+    startDate = startDate.with({ day: 1 })
   }
 
   const dayWidth = DAY_WIDTH[granularity]
-  const totalDays = calendarDayDiff(startDate, endDate)
+  const totalDays = endDate.since(startDate, { largestUnit: 'days' }).days
   return {
     startDate,
     endDate,
@@ -77,27 +77,12 @@ export function buildTimelineConfig(tasks: Task[], granularity: GanttGranularity
   }
 }
 
-/** Calendar-day difference, DST-safe (uses UTC noon to dodge transitions). */
-function calendarDayDiff(from: Date, to: Date): number {
-  const a = Date.UTC(from.getFullYear(), from.getMonth(), from.getDate(), 12)
-  const b = Date.UTC(to.getFullYear(), to.getMonth(), to.getDate(), 12)
-  return Math.round((b - a) / DAY_MS)
+export function dateToX(cfg: TimelineCfg, date: Temporal.PlainDate): number {
+  return date.since(cfg.startDate, { largestUnit: 'days' }).days * cfg.dayWidth
 }
 
-export function dateToX(cfg: TimelineCfg, date: Date): number {
-  return calendarDayDiff(cfg.startDate, date) * cfg.dayWidth
-}
-
-export function xToDate(cfg: TimelineCfg, x: number): Date {
-  const days = Math.round(x / cfg.dayWidth)
-  return new Date(cfg.startDate.getFullYear(), cfg.startDate.getMonth(), cfg.startDate.getDate() + days)
-}
-
-export function dateToIso(d: Date): string {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
+export function xToDate(cfg: TimelineCfg, x: number): Temporal.PlainDate {
+  return cfg.startDate.add({ days: Math.round(x / cfg.dayWidth) })
 }
 
 /**
@@ -112,19 +97,18 @@ export function getSnapPoints(cfg: TimelineCfg): number[] {
   const { startDate, totalDays, dayWidth, granularity } = cfg
 
   for (let i = 0; i <= totalDays; i++) {
-    const d = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + i)
+    const d = startDate.add({ days: i })
     const x = i * dayWidth
 
     if (granularity === 'day') {
       points.push(x)
     } else if (granularity === 'week') {
-      const dow = d.getDay()
-      if (dow === 1 || dow === 4) points.push(x) // Monday, Thursday
+      // Temporal dayOfWeek: Mon=1..Sun=7
+      if (d.dayOfWeek === 1 || d.dayOfWeek === 4) points.push(x)
     } else if (granularity === 'month') {
-      const day = d.getDate()
-      if (day === 1 || day === 8 || day === 15 || day === 22) points.push(x)
+      if (d.day === 1 || d.day === 8 || d.day === 15 || d.day === 22) points.push(x)
     } else if (granularity === 'quarter') {
-      if (d.getDate() === 1) points.push(x)
+      if (d.day === 1) points.push(x)
     }
   }
   return points
@@ -145,9 +129,6 @@ export function snapX(x: number, snapPoints: number[], threshold: number): numbe
   return minDist <= threshold ? closest : x
 }
 
-export function getWeekNumber(d: Date): number {
-  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
-  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7))
-  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
-  return Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
+export function getWeekNumber(d: Temporal.PlainDate): number {
+  return d.weekOfYear ?? 0
 }

--- a/src/views/table/BulkActionBar.ts
+++ b/src/views/table/BulkActionBar.ts
@@ -1,7 +1,8 @@
 import { Menu } from 'obsidian'
 import type { Task, TaskStatus, TaskPriority } from '../../types'
 import { findTask, flattenTasks, collectAllAssignees, collectAllTags } from '../../store'
-import { formatBadgeText, toIsoDate } from '../../utils'
+import { formatBadgeText } from '../../utils'
+import { today } from '../../dates'
 import { promptText } from '../../ui/ModalFactory'
 import { TaskPickerModal } from '../../modals/PickerModals'
 import type { TableContext } from './TableRenderer'
@@ -140,31 +141,19 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   const dueBtn = left.createEl('button', { text: 'Set due date', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
   dueBtn.addEventListener('click', (e) => {
     const menu = new Menu()
-    const today = new Date()
-    const addDays = (days: number) => {
-      const d = new Date(today)
-      d.setDate(d.getDate() + days)
-      return d
-    }
+    const now = today()
+    const ahead = (days: number) => now.add({ days }).toString()
     menu.addItem((item) =>
-      item
-        .setTitle(`Today (${toIsoDate(today)})`)
-        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(today) }))
+      item.setTitle(`Today (${ahead(0)})`).onClick(() => onAction({ type: 'set-due-date', due: ahead(0) }))
     )
     menu.addItem((item) =>
-      item
-        .setTitle(`Tomorrow (${toIsoDate(addDays(1))})`)
-        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(addDays(1)) }))
+      item.setTitle(`Tomorrow (${ahead(1)})`).onClick(() => onAction({ type: 'set-due-date', due: ahead(1) }))
     )
     menu.addItem((item) =>
-      item
-        .setTitle(`In 1 week (${toIsoDate(addDays(7))})`)
-        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(addDays(7)) }))
+      item.setTitle(`In 1 week (${ahead(7)})`).onClick(() => onAction({ type: 'set-due-date', due: ahead(7) }))
     )
     menu.addItem((item) =>
-      item
-        .setTitle(`In 2 weeks (${toIsoDate(addDays(14))})`)
-        .onClick(() => onAction({ type: 'set-due-date', due: toIsoDate(addDays(14)) }))
+      item.setTitle(`In 2 weeks (${ahead(14)})`).onClick(() => onAction({ type: 'set-due-date', due: ahead(14) }))
     )
     menu.addSeparator()
     menu.addItem((item) =>

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -4,13 +4,13 @@ import { totalLoggedHours } from '../../store/TaskTreeOps'
 import {
   stringToColor,
   formatDateLong,
-  todayMidnight,
   isTaskOverdue,
   getStatusConfig,
   getPriorityConfig,
   safeAsync,
   stringifyCustomValue
 } from '../../utils'
+import { today, parsePlainDate } from '../../dates'
 import { COLOR_ACCENT } from '../../constants'
 import { renderStatusBadge, renderPriorityBadge } from '../../ui/StatusBadge'
 import { openTaskModal } from '../../ui/ModalFactory'
@@ -255,10 +255,9 @@ export function renderDueDateCell(row: HTMLElement, task: Task, ctx: TableContex
     return
   }
 
-  const dueDate = new Date(task.due)
-  const today = todayMidnight()
+  const due = parsePlainDate(task.due)
   const overdue = isTaskOverdue(task, ctx.plugin.settings.statuses)
-  const isNear = !overdue && dueDate.getTime() - today.getTime() < 3 * 86400_000
+  const isNear = !overdue && due !== null && due.since(today(), { largestUnit: 'days' }).days < 3
 
   const chip = cell.createEl('span', {
     text: formatDateLong(task.due),

--- a/src/views/table/TableFilters.ts
+++ b/src/views/table/TableFilters.ts
@@ -1,7 +1,8 @@
 import type { Task, FilterState, TaskPriority, DueDateFilter, StatusConfig } from '../../types'
 import type { FlatTask } from '../../store/TaskTreeOps'
 import type { TableState } from './TableRenderer'
-import { isTerminalStatus, statusSortOrder, todayMidnight } from '../../utils'
+import { isTerminalStatus, statusSortOrder } from '../../utils'
+import { Temporal, today, parsePlainDate } from '../../dates'
 
 export function isFilterActive(filter: FilterState): boolean {
   return !!(
@@ -43,29 +44,23 @@ export function applyFilters(flat: FlatTask[], filter: FilterState, statuses: St
 }
 
 function matchDueDateFilter(task: Task, filter: DueDateFilter, statuses: StatusConfig[] = []): boolean {
-  const today = todayMidnight()
+  if (filter === 'no-date') return !task.due
+  const due = parsePlainDate(task.due)
+  if (!due) return false
+  const now = today()
 
   switch (filter) {
-    case 'no-date':
-      return !task.due
-    case 'overdue': {
-      if (!task.due) return false
-      const d = new Date(task.due)
-      return d < today && !isTerminalStatus(task.status, statuses)
-    }
+    case 'overdue':
+      return Temporal.PlainDate.compare(due, now) < 0 && !isTerminalStatus(task.status, statuses)
     case 'this-week': {
-      if (!task.due) return false
-      const d = new Date(task.due)
-      const endOfWeek = new Date(today)
-      const dayOfWeek = today.getDay()
-      endOfWeek.setDate(today.getDate() + (7 - dayOfWeek))
-      return d >= today && d <= endOfWeek
+      // Preserve pre-Temporal behavior: the original used JS getDay (Sunday=0..Saturday=6)
+      // and added `7 - dayOfWeek` days, so the window ran from today through the upcoming Sunday.
+      const daysToEnd = 7 - (now.dayOfWeek % 7) // Temporal dayOfWeek: Mon=1..Sun=7
+      const endOfWeek = now.add({ days: daysToEnd })
+      return Temporal.PlainDate.compare(due, now) >= 0 && Temporal.PlainDate.compare(due, endOfWeek) <= 0
     }
-    case 'this-month': {
-      if (!task.due) return false
-      const d = new Date(task.due)
-      return d.getMonth() === today.getMonth() && d.getFullYear() === today.getFullYear() && d >= today
-    }
+    case 'this-month':
+      return due.year === now.year && due.month === now.month && Temporal.PlainDate.compare(due, now) >= 0
     default:
       return true
   }


### PR DESCRIPTION
Adopt `temporal-polyfill` for all date handling. Fixes the UTC off-by-one where "today" rolled over in the evening west of UTC.

New `src/dates.ts` is the single Temporal import site. Every date site now uses `Temporal.PlainDate`: `Scheduler`, `Notifier`, `TableFilters`, `TableCellRenderers`, `BulkActionBar`, `TimeTrackingPanel`, `makeTask`, `isTaskOverdue`, and the entire Gantt stack (TimelineConfig, renderers, header, drag handler).

`utils.ts` has no date helpers left. `DAY_MS`, `dateToIso`, `calendarDayDiff`, and the UTC-noon DST trick are gone.

Bundle: 137 to 194 KB raw / 36 to 56 KB gzip.