### PR TITLE
rewrite view and tab management

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
-import { Plugin, TFile, Notice } from 'obsidian'
+import { MarkdownView, Plugin, Notice } from 'obsidian'
 import { DEFAULT_SETTINGS, PMSettings, Project } from './types'
 import { flattenTasks } from './store/TaskTreeOps'
 import { ProjectStore } from './store'
 import { PMSettingTab } from './settings'
-import { ProjectView, PM_VIEW_TYPE } from './views/ProjectView'
+import { ProjectView, PM_PROJECT_VIEW_TYPE } from './views/ProjectView'
+import { DashboardView, PM_DASHBOARD_VIEW_TYPE } from './views/DashboardView'
+import { PMViewRouter } from './views/PMViewRouter'
 import { openProjectModal, openTaskModal, openProjectPicker, openTaskPicker, openImportModal } from './ui/ModalFactory'
 import { Notifier } from './components/Notifier'
 import { migrateProjects } from './migration'
@@ -13,9 +15,9 @@ export default class PMPlugin extends Plugin {
   settings: PMSettings = { ...DEFAULT_SETTINGS }
   store!: ProjectStore
   notifier!: Notifier
+  router!: PMViewRouter
   undoStack: Array<{ undo: () => Promise<void>; redo: () => Promise<void> }> = []
   redoStack: Array<{ undo: () => Promise<void>; redo: () => Promise<void> }> = []
-  private _openingProjectFile: string | null = null
 
   pushUndo(entry: { undo: () => Promise<void>; redo: () => Promise<void> }): void {
     this.undoStack.push(entry)
@@ -43,44 +45,26 @@ export default class PMPlugin extends Plugin {
     await this.loadSettings()
     this.store = new ProjectStore(this.app, () => this.settings.statuses)
     this.notifier = new Notifier(this)
+    this.router = new PMViewRouter(this)
 
-    // Register the custom view
-    this.registerView(PM_VIEW_TYPE, (leaf) => new ProjectView(leaf, this))
+    this.registerView(PM_PROJECT_VIEW_TYPE, (leaf) => new ProjectView(leaf, this))
+    this.registerView(PM_DASHBOARD_VIEW_TYPE, (leaf) => new DashboardView(leaf, this))
 
-    // Open project files in the custom view
-    this.registerExtensions([], 'md') // handled via onOpenFile
     this.app.workspace.onLayoutReady(
       safeAsync(async () => {
-        // Run migration for old-format projects
         await migrateProjects(this)
-
-        this.registerEvent(
-          this.app.workspace.on(
-            'file-open',
-            safeAsync(async (file: TFile | null) => {
-              if (!file) return
-              const cache = this.app.metadataCache.getFileCache(file)
-              const fm = cache?.frontmatter
-              if (fm?.['pm-project'] === true) {
-                await this.openProjectFile(file)
-              }
-            })
-          )
-        )
       })
     )
 
-    // Ribbon icon
     this.addRibbonIcon('chart-gantt', 'Project manager', async () => {
-      await this.openProjectsPane()
+      await this.router.openDashboard()
     })
 
-    // Commands
     this.addCommand({
       id: 'open-projects',
       name: 'Open projects pane',
       callback: () => {
-        void this.openProjectsPane()
+        void this.router.openDashboard()
       }
     })
 
@@ -90,7 +74,7 @@ export default class PMPlugin extends Plugin {
       callback: () => {
         openProjectModal(this, {
           onSave: async (project) => {
-            await this.openProjectByPath(project.filePath)
+            await this.router.openProjectByPath(project.filePath)
           }
         })
       }
@@ -136,10 +120,22 @@ export default class PMPlugin extends Plugin {
       }
     })
 
-    // Settings tab
-    this.addSettingTab(new PMSettingTab(this.app, this))
+    this.addCommand({
+      id: 'open-current-as-project',
+      name: 'Open current file as project',
+      checkCallback: (checking: boolean) => {
+        const md = this.app.workspace.getActiveViewOfType(MarkdownView)
+        const file = md?.file
+        if (!file) return false
+        const cache = this.app.metadataCache.getFileCache(file)
+        if (cache?.frontmatter?.['pm-project'] !== true) return false
+        if (checking) return true
+        void md.leaf.setViewState({ type: PM_PROJECT_VIEW_TYPE, state: { filePath: file.path } })
+        return true
+      }
+    })
 
-    // Start notifier
+    this.addSettingTab(new PMSettingTab(this.app, this))
     this.notifier.start()
   }
 
@@ -150,11 +146,9 @@ export default class PMPlugin extends Plugin {
   async loadSettings(): Promise<void> {
     const saved = (await this.loadData()) as Partial<PMSettings> | null
     this.settings = Object.assign({}, DEFAULT_SETTINGS, saved ?? {})
-    // Merge nested arrays carefully
     if (!saved?.statuses?.length) this.settings.statuses = DEFAULT_SETTINGS.statuses
     if (!saved?.priorities?.length) this.settings.priorities = DEFAULT_SETTINGS.priorities
 
-    // Migrate pre-v1.3 statuses: add `complete` flag if missing
     let migrated = false
     for (const s of this.settings.statuses) {
       if (s.complete === undefined) {
@@ -167,46 +161,6 @@ export default class PMPlugin extends Plugin {
 
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings)
-  }
-
-  async openProjectsPane(): Promise<void> {
-    const existing = this.app.workspace
-      .getLeavesOfType(PM_VIEW_TYPE)
-      .find((leaf) => (leaf.view as unknown as ProjectView).filePath === '')
-    if (existing) {
-      await this.app.workspace.revealLeaf(existing)
-      return
-    }
-    const leaf = this.app.workspace.getLeaf('tab')
-    await leaf.setViewState({ type: PM_VIEW_TYPE, state: {} })
-    await this.app.workspace.revealLeaf(leaf)
-  }
-
-  async openProjectFile(file: TFile): Promise<void> {
-    if (this._openingProjectFile === file.path) return
-    this._openingProjectFile = file.path
-    try {
-      for (const leaf of this.app.workspace.getLeavesOfType(PM_VIEW_TYPE)) {
-        const view = leaf.view as unknown as ProjectView
-        if (view.filePath === file.path) {
-          await this.app.workspace.revealLeaf(leaf)
-          return
-        }
-      }
-      const leaf = this.app.workspace.getLeaf('tab')
-      await leaf.setViewState({
-        type: PM_VIEW_TYPE,
-        state: { filePath: file.path }
-      })
-      await this.app.workspace.revealLeaf(leaf)
-    } finally {
-      this._openingProjectFile = null
-    }
-  }
-
-  async openProjectByPath(path: string): Promise<void> {
-    const file = this.app.vault.getAbstractFileByPath(path)
-    if (file instanceof TFile) await this.openProjectFile(file)
   }
 
   showNotice(msg: string, duration = 3000): void {
@@ -222,7 +176,6 @@ export default class PMPlugin extends Plugin {
     }
     openProjectPicker(this, projects, (project) => {
       if (mode === 'pick-parent') {
-        // Pick a parent task
         const flat = flattenTasks(project.tasks)
         if (!flat.length) {
           this.showNotice('No tasks in this project. Create a task first.')
@@ -246,35 +199,32 @@ export default class PMPlugin extends Plugin {
       parentId,
       onSave: async () => {
         await this.store.saveProject(project)
-        await this.openProjectByPath(project.filePath)
+        await this.router.openProjectByPath(project.filePath)
       }
     })
   }
 
   private async importNotes(): Promise<void> {
-    // Try to find an active project view with a project
-    const activeLeaves = this.app.workspace.getLeavesOfType(PM_VIEW_TYPE)
+    const activeLeaves = this.app.workspace.getLeavesOfType(PM_PROJECT_VIEW_TYPE)
     let activeProject: Project | null = null
 
     for (const leaf of activeLeaves) {
-      const view = leaf.view as unknown as ProjectView
-      if (view.project) {
-        activeProject = view.project
+      if (!(leaf.view instanceof ProjectView)) continue
+      if (leaf.view.project) {
+        activeProject = leaf.view.project
         break
       }
     }
 
-    // If a project is open, use it directly
     if (activeProject) {
       const project = activeProject
       const onImportComplete = async () => {
-        await this.openProjectByPath(project.filePath)
+        await this.router.openProjectByPath(project.filePath)
       }
       openImportModal(this, activeProject, onImportComplete)
       return
     }
 
-    // Otherwise, show project picker first
     const projects = await this.store.loadAllProjects(this.settings.projectsFolder)
     if (!projects.length) {
       this.showNotice('No projects yet. Create a project first.')
@@ -283,7 +233,7 @@ export default class PMPlugin extends Plugin {
 
     openProjectPicker(this, projects, (project) => {
       const onImportComplete = async () => {
-        await this.openProjectByPath(project.filePath)
+        await this.router.openProjectByPath(project.filePath)
       }
       openImportModal(this, project, onImportComplete)
     })

--- a/src/views/DashboardView.ts
+++ b/src/views/DashboardView.ts
@@ -1,0 +1,59 @@
+import { ItemView, WorkspaceLeaf, TFile } from 'obsidian'
+import type PMPlugin from '../main'
+import { renderProjectListToolbar, renderProjectListContent } from './ProjectListRenderer'
+import type { ProjectListContext } from './ProjectListRenderer'
+
+export const PM_DASHBOARD_VIEW_TYPE = 'pm-dashboard'
+
+export class DashboardView extends ItemView {
+  private plugin: PMPlugin
+  private toolbarEl!: HTMLElement
+  private contentEl2!: HTMLElement
+  private renderToken = 0
+
+  constructor(leaf: WorkspaceLeaf, plugin: PMPlugin) {
+    super(leaf)
+    this.plugin = plugin
+    this.navigation = false
+  }
+
+  getViewType(): string {
+    return PM_DASHBOARD_VIEW_TYPE
+  }
+  getDisplayText(): string {
+    return 'Projects'
+  }
+  getIcon(): string {
+    return 'chart-gantt'
+  }
+
+  onOpen(): Promise<void> {
+    this.containerEl.addClass('pm-view')
+    const root = this.contentEl
+    root.empty()
+    root.addClass('pm-root')
+    this.toolbarEl = root.createDiv('pm-toolbar')
+    this.contentEl2 = root.createDiv('pm-content')
+    this.render()
+    return Promise.resolve()
+  }
+
+  render(): void {
+    const ctx = this.makeCtx()
+    renderProjectListToolbar(ctx)
+    this.contentEl2.empty()
+    this.contentEl2.addClass('pm-project-list-container')
+    void renderProjectListContent(ctx)
+  }
+
+  private makeCtx(): ProjectListContext {
+    const token = ++this.renderToken
+    return {
+      plugin: this.plugin,
+      toolbarEl: this.toolbarEl,
+      contentEl: this.contentEl2,
+      isStale: () => token !== this.renderToken,
+      openProjectFile: (file: TFile) => this.plugin.router.openProject(file)
+    }
+  }
+}

--- a/src/views/PMViewRouter.ts
+++ b/src/views/PMViewRouter.ts
@@ -1,0 +1,27 @@
+import { TFile } from 'obsidian'
+import type PMPlugin from '../main'
+import { PM_DASHBOARD_VIEW_TYPE } from './DashboardView'
+import { PM_PROJECT_VIEW_TYPE } from './ProjectView'
+
+export class PMViewRouter {
+  constructor(private plugin: PMPlugin) {}
+
+  async openDashboard(): Promise<void> {
+    const ws = this.plugin.app.workspace
+    const leaf = ws.getLeaf('tab')
+    await leaf.setViewState({ type: PM_DASHBOARD_VIEW_TYPE, state: {} })
+    await ws.revealLeaf(leaf)
+  }
+
+  async openProject(file: TFile): Promise<void> {
+    const ws = this.plugin.app.workspace
+    const leaf = ws.getLeaf('tab')
+    await leaf.setViewState({ type: PM_PROJECT_VIEW_TYPE, state: { filePath: file.path } })
+    await ws.revealLeaf(leaf)
+  }
+
+  async openProjectByPath(path: string): Promise<void> {
+    const file = this.plugin.app.vault.getAbstractFileByPath(path)
+    if (file instanceof TFile) await this.openProject(file)
+  }
+}

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -8,13 +8,11 @@ import type { TableViewState } from './table/TableView'
 import { GanttView } from './gantt/GanttView'
 import { KanbanView } from './KanbanView'
 import { openProjectModal, openTaskModal } from '../ui/ModalFactory'
-import { renderProjectListToolbar, renderProjectListContent } from './ProjectListRenderer'
-import type { ProjectListContext } from './ProjectListRenderer'
 
-export const PM_VIEW_TYPE = 'pm-project-view'
+export const PM_PROJECT_VIEW_TYPE = 'pm-project'
 
-interface ViewState {
-  filePath?: string
+interface ProjectViewState {
+  filePath: string
   [key: string]: unknown
 }
 
@@ -30,7 +28,6 @@ export class ProjectView extends ItemView {
   private titleEl2!: HTMLElement
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null
   private fileModifyRef: EventRef | null = null
-  private renderToken = 0
   private reloadDebounceTimer: number | null = null
 
   constructor(leaf: WorkspaceLeaf, plugin: PMPlugin) {
@@ -41,43 +38,45 @@ export class ProjectView extends ItemView {
   }
 
   getViewType(): string {
-    return PM_VIEW_TYPE
+    return PM_PROJECT_VIEW_TYPE
   }
   getDisplayText(): string {
-    return truncateTitle(this.project?.title ?? 'PM', 10)
+    return truncateTitle(this.project?.title ?? 'Project', 10)
   }
   getIcon(): string {
     return 'chart-gantt'
   }
 
-  async setState(state: ViewState, result: unknown): Promise<void> {
-    if (state.filePath) {
+  async setState(state: ProjectViewState, result: unknown): Promise<void> {
+    if (state.filePath && state.filePath !== this.filePath) {
       this.filePath = state.filePath
       await this.loadProject()
     }
     await super.setState(state, result as import('obsidian').ViewStateResult)
   }
 
-  getState(): ViewState {
+  getState(): ProjectViewState {
     return { filePath: this.filePath }
   }
 
   async onOpen(): Promise<void> {
     this.containerEl.addClass('pm-view')
-    this.buildSkeleton()
+    const root = this.contentEl
+    root.empty()
+    root.addClass('pm-root')
+    this.toolbarEl = root.createDiv('pm-toolbar')
+    this.contentEl2 = root.createDiv('pm-content')
+
     if (this.filePath) await this.loadProject()
-    else this.renderProjectList()
 
     this.keydownHandler = (e: KeyboardEvent) => {
       this.subview?.handleKeyDown?.(e)
     }
     this.containerEl.addEventListener('keydown', this.keydownHandler)
-    // Make container focusable so it receives keyboard events
     if (!this.containerEl.hasAttribute('tabindex')) {
       this.containerEl.setAttribute('tabindex', '-1')
     }
 
-    // Watch for task file modifications/deletions to keep the view in sync
     const reloadIfRelevant = (filePath: string) => {
       if (!this.project || !this.filePath) return false
       const taskFolder = this.filePath.replace(/\.md$/, '_tasks')
@@ -122,65 +121,34 @@ export class ProjectView extends ItemView {
     return Promise.resolve()
   }
 
-  // ─── Skeleton ──────────────────────────────────────────────────────────────
-
-  private buildSkeleton(): void {
-    const root = this.contentEl
-    root.empty()
-    root.addClass('pm-root')
-
-    // Toolbar
-    this.toolbarEl = root.createDiv('pm-toolbar')
-
-    // Content area
-    this.contentEl2 = root.createDiv('pm-content')
-  }
-
-  // ─── Project list (when no file is open) ───────────────────────────────────
-
-  private getProjectListCtx(): ProjectListContext {
-    const token = ++this.renderToken
-    return {
-      plugin: this.plugin,
-      toolbarEl: this.toolbarEl,
-      contentEl: this.contentEl2,
-      isStale: () => token !== this.renderToken,
-      openProjectFile: (file: TFile) => this.plugin.openProjectFile(file)
-    }
-  }
-
-  private renderProjectList(): void {
-    const ctx = this.getProjectListCtx()
-    renderProjectListToolbar(ctx)
-    this.contentEl2.empty()
-    this.contentEl2.addClass('pm-project-list-container')
-    void renderProjectListContent(ctx)
-  }
-
-  // ─── Project view ──────────────────────────────────────────────────────────
-
   private async loadProject(): Promise<void> {
     const file = this.app.vault.getAbstractFileByPath(this.filePath)
     if (!(file instanceof TFile)) {
-      this.renderProjectList()
+      this.renderMissingProject()
       return
     }
     this.project = await this.plugin.store.loadProject(file)
     if (!this.project) {
-      this.renderProjectList()
+      this.renderMissingProject()
       return
     }
-    // Update tab header text and icon after project loads
     ;(this.leaf as WorkspaceLeaf & { updateHeader?: () => void }).updateHeader?.()
     this.renderProjectToolbar()
     this.renderCurrentView()
+  }
+
+  private renderMissingProject(): void {
+    this.toolbarEl.empty()
+    this.contentEl2.empty()
+    const msg = this.contentEl2.createDiv('pm-empty-state')
+    msg.createEl('h3', { text: 'Project not found' })
+    msg.createEl('p', { text: `No project at ${this.filePath}. It may have been deleted or renamed.` })
   }
 
   private renderProjectToolbar(): void {
     if (!this.project) return
     this.toolbarEl.empty()
 
-    // Left: icon, title, description
     const left = this.toolbarEl.createDiv('pm-toolbar-left')
     const iconEl = left.createEl('span', {
       text: this.project.icon,
@@ -208,7 +176,6 @@ export class ProjectView extends ItemView {
       })
     )
 
-    // Center: view switcher
     const switcher = this.toolbarEl.createDiv('pm-view-switcher')
     const views: { mode: ViewMode; icon: string; label: string }[] = [
       { mode: 'table', icon: '≡', label: 'Table' },
@@ -231,7 +198,6 @@ export class ProjectView extends ItemView {
       })
     }
 
-    // Right: actions
     const right = this.toolbarEl.createDiv('pm-toolbar-right')
     const addBtn = right.createEl('button', { text: '+ add task', cls: 'pm-btn pm-btn-primary' })
     addBtn.addEventListener('click', () => {
@@ -275,13 +241,10 @@ export class ProjectView extends ItemView {
 
   private renderCurrentView(): void {
     if (!this.project) return
-    this.renderToken++ // cancel any in-flight project list render
 
-    // Preserve quick-add focus across re-renders
     const quickAddFocused =
       activeDocument.activeElement instanceof HTMLElement && activeDocument.activeElement.matches('.pm-quick-add-input')
 
-    // Save Gantt scroll position and label width before destroying the old view
     let savedGanttScroll: ReturnType<GanttView['getScrollPosition']> | null = null
     let savedGanttLabelWidth: number | null = null
     if (this.currentView === 'gantt' && this.subview instanceof GanttView) {
@@ -289,7 +252,6 @@ export class ProjectView extends ItemView {
       savedGanttLabelWidth = this.subview.getLabelWidth()
     }
 
-    // Save TableView filter/sort state so it survives project reloads
     if (this.subview instanceof TableView) {
       this.savedTableViewState = this.subview.getViewState()
     } else if (this.currentView !== 'table') {
@@ -323,7 +285,6 @@ export class ProjectView extends ItemView {
     }
     this.subview?.render()
 
-    // Restore quick-add focus after re-render
     if (quickAddFocused) {
       const newInput = this.contentEl2.querySelector('.pm-quick-add-input') as HTMLInputElement
       if (newInput) newInput.focus()
@@ -332,7 +293,6 @@ export class ProjectView extends ItemView {
 
   async refreshProject(): Promise<void> {
     if (!this.filePath) return
-    // Cancel any pending file-modify reload — we're handling it here
     if (this.reloadDebounceTimer !== null) {
       activeWindow.clearTimeout(this.reloadDebounceTimer)
       this.reloadDebounceTimer = null

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,12 +2,14 @@ import { builtinModules } from 'node:module'
 import { defineConfig } from 'tsdown'
 
 const prod = Boolean(process.env['PRODUCTION'])
+const vaultPath = process.env['VAULT_PATH']
+const outDir = vaultPath ? `${vaultPath}/.obsidian/plugins/project-manager` : '.'
 
 export default defineConfig({
   entry: 'src/main.ts',
   format: 'cjs',
   target: 'es2022',
-  outDir: '.',
+  outDir,
   platform: 'node',
   dts: false,
   minify: prod,


### PR DESCRIPTION
## Summary

- Split ProjectView into DashboardView and a single-project ProjectView. Separate view types, so dedup and lookup can't cross-pollute.
- PMViewRouter owns leaf/tab handling. Dropped the file-open hijack, the re-entrancy guard, the stale-leaf sweep, and the history-rewind. Clicking a project file in the sidebar now does what Obsidian does by default.
- New command "Open current file as project" converts the active markdown leaf to the PM view when the file has pm-project frontmatter. Bind it to a hotkey if you want the old auto-redirect.
- tsdown reads VAULT_PATH and writes main.js into that vault's plugin folder, so pnpm dev doesn't need a copy step.

Fixes #20 and the tab-hijack issue when clicking a project from a task tab.