### PR TITLE
add duplicate task action

### DIFF
--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -1,7 +1,15 @@
 import { App, Notice, TFile, TFolder, normalizePath } from 'obsidian'
 import type { Project, Task, StatusConfig } from '../types'
 import { makeProject, makeTask } from '../types'
-import { updateTaskInTree, deleteTaskFromTree, addTaskToTree, findTask } from './TaskTreeOps'
+import {
+  updateTaskInTree,
+  deleteTaskFromTree,
+  addTaskToTree,
+  findTask,
+  flattenTasks,
+  moveTaskInTree,
+  cloneTaskSubtree
+} from './TaskTreeOps'
 import { computeSchedule } from './Scheduler'
 import { archiveTask as doArchiveTask, unarchiveTask as doUnarchiveTask } from './ArchiveOps'
 import { parseFrontmatter, FRONTMATTER_KEY, TASK_FRONTMATTER_KEY } from './YamlParser'
@@ -281,6 +289,18 @@ export class ProjectStore {
   async insertTask(project: Project, task: Task, parentId: string | null = null): Promise<void> {
     addTaskToTree(project.tasks, task, parentId)
     await this.saveProject(project)
+  }
+
+  async duplicateTask(project: Project, sourceId: string, includeSubtasks: boolean): Promise<Task | null> {
+    const source = findTask(project.tasks, sourceId)
+    if (!source) return null
+    const copy = cloneTaskSubtree(source, includeSubtasks)
+    copy.title = `${source.title} (copy)`
+    const parentId = flattenTasks(project.tasks).find((f) => f.task.id === sourceId)?.parentId ?? null
+    addTaskToTree(project.tasks, copy, parentId)
+    moveTaskInTree(project.tasks, copy.id, sourceId, 'after')
+    await this.saveProject(project)
+    return copy
   }
 
   async moveTask(project: Project, taskId: string, newParentId: string | null): Promise<void> {

--- a/src/store/TaskTreeOps.ts
+++ b/src/store/TaskTreeOps.ts
@@ -1,4 +1,5 @@
 import type { Task, StatusConfig } from '../types'
+import { makeId } from '../types'
 import { isTerminalStatus } from '../utils'
 
 /** Flatten a task tree into a list, preserving depth info */
@@ -69,6 +70,47 @@ export function addTaskToTree(tasks: Task[], newTask: Task, parentId: string | n
   const parent = findTask(tasks, parentId)
   if (parent) parent.subtasks.push(newTask)
   else tasks.push(newTask)
+}
+
+/**
+ * Deep-clone a task subtree with fresh ids, timestamps, and no file paths.
+ * When includeSubtasks is false, the clone has no children and its dependencies
+ * are copied verbatim (they still point at originals in the project).
+ * When includeSubtasks is true, the whole subtree is cloned and dependencies
+ * that target another node within the subtree are remapped to the new ids;
+ * dependencies pointing outside the subtree are preserved as-is.
+ */
+export function cloneTaskSubtree(source: Task, includeSubtasks: boolean): Task {
+  const idMap = new Map<string, string>()
+  const clone = cloneNode(source, includeSubtasks, idMap)
+  if (includeSubtasks) remapDeps(clone, idMap)
+  return clone
+}
+
+function cloneNode(source: Task, includeSubtasks: boolean, idMap: Map<string, string>): Task {
+  const now = new Date().toISOString()
+  const newId = makeId()
+  idMap.set(source.id, newId)
+  return {
+    ...source,
+    id: newId,
+    filePath: undefined,
+    createdAt: now,
+    updatedAt: now,
+    collapsed: false,
+    subtasks: includeSubtasks ? source.subtasks.map((s) => cloneNode(s, true, idMap)) : [],
+    dependencies: [...source.dependencies],
+    assignees: [...source.assignees],
+    tags: [...source.tags],
+    customFields: { ...source.customFields },
+    timeLogs: source.timeLogs ? source.timeLogs.map((l) => ({ ...l })) : undefined,
+    recurrence: source.recurrence ? { ...source.recurrence } : undefined
+  }
+}
+
+function remapDeps(task: Task, idMap: Map<string, string>): void {
+  task.dependencies = task.dependencies.map((id) => idMap.get(id) ?? id)
+  for (const sub of task.subtasks) remapDeps(sub, idMap)
 }
 
 /** Move a task before or after another task in the tree (same level) */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,6 +9,7 @@ export {
   deleteTaskFromTree,
   addTaskToTree,
   moveTaskInTree,
+  cloneTaskSubtree,
   totalLoggedHours,
   filterArchived,
   filterDone,

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -18,6 +18,17 @@ export function confirmDialog(app: App, message: string, confirmLabel = 'Delete'
 }
 
 /**
+ * Asks the user whether to duplicate a task with or without its subtasks.
+ * Resolves to the chosen mode, or null if cancelled.
+ */
+export function confirmDuplicateSubtasks(app: App, taskTitle: string): Promise<'with-subtasks' | 'task-only' | null> {
+  return new Promise((resolve) => {
+    const modal = new DuplicateSubtasksModal(app, taskTitle, resolve)
+    modal.open()
+  })
+}
+
+/**
  * Opens an Obsidian-native text input prompt.
  * Returns the trimmed string, or null if cancelled/empty.
  */
@@ -141,6 +152,59 @@ class ConfirmModal extends Modal {
 
   onClose(): void {
     this.finish(false)
+    this.contentEl.empty()
+  }
+}
+
+class DuplicateSubtasksModal extends Modal {
+  private resolved = false
+
+  constructor(
+    app: App,
+    private taskTitle: string,
+    private resolve: (value: 'with-subtasks' | 'task-only' | null) => void
+  ) {
+    super(app)
+  }
+
+  private finish(value: 'with-subtasks' | 'task-only' | null): void {
+    if (this.resolved) return
+    this.resolved = true
+    this.resolve(value)
+  }
+
+  onOpen(): void {
+    const { contentEl } = this
+    this.modalEl.addClass('pm-confirm-modal')
+
+    contentEl.createEl('p', {
+      text: `Duplicate "${this.taskTitle}" with its subtasks?`,
+      cls: 'pm-confirm-text'
+    })
+
+    const btnRow = contentEl.createDiv('pm-modal-btn-row')
+
+    const cancelBtn = btnRow.createEl('button', { text: 'Cancel', cls: 'mod-muted' })
+    cancelBtn.addEventListener('click', () => {
+      this.finish(null)
+      this.close()
+    })
+
+    const taskOnlyBtn = btnRow.createEl('button', { text: 'Task only' })
+    taskOnlyBtn.addEventListener('click', () => {
+      this.finish('task-only')
+      this.close()
+    })
+
+    const withSubtasksBtn = btnRow.createEl('button', { text: 'With subtasks', cls: 'mod-cta' })
+    withSubtasksBtn.addEventListener('click', () => {
+      this.finish('with-subtasks')
+      this.close()
+    })
+  }
+
+  onClose(): void {
+    this.finish(null)
     this.contentEl.empty()
   }
 }

--- a/src/ui/TaskContextMenu.ts
+++ b/src/ui/TaskContextMenu.ts
@@ -2,7 +2,7 @@ import { Menu, Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Task, Project } from '../types'
 import { safeAsync } from '../utils'
-import { openTaskModal, confirmDialog } from './ModalFactory'
+import { openTaskModal, confirmDialog, confirmDuplicateSubtasks } from './ModalFactory'
 
 export interface TaskMenuContext {
   plugin: PMPlugin
@@ -39,6 +39,23 @@ export function buildTaskContextMenu(menu: Menu, task: Task, ctx: TaskMenuContex
           }
         })
       })
+  )
+  menu.addItem((item) =>
+    item
+      .setTitle('Duplicate task')
+      .setIcon('copy')
+      .onClick(
+        safeAsync(async () => {
+          let includeSubtasks = false
+          if (task.subtasks.length > 0) {
+            const choice = await confirmDuplicateSubtasks(ctx.plugin.app, task.title)
+            if (choice === null) return
+            includeSubtasks = choice === 'with-subtasks'
+          }
+          await ctx.plugin.store.duplicateTask(ctx.project, task.id, includeSubtasks)
+          await ctx.onRefresh()
+        })
+      )
   )
   menu.addSeparator()
   if (task.archived) {


### PR DESCRIPTION
- context menu in table and kanban now has "duplicate task". when the source has children it asks whether to include them; otherwise it runs straight through.
- `ProjectStore.duplicateTask` inserts the copy right after the source, titles it `"{source.title} (copy)"`, and mints fresh ids/timestamps for every cloned node.
- deps pointing at other nodes in the copied subtree get rewritten to the new ids. deps pointing outside stay as-is. no other task's dependencies get updated, so inbound refs still point at the original.
- archived source puts the copy in Archive/ alongside it. each cloned node keeps its own archived flag.