### PR TITLE
UI primitives

### DIFF
--- a/src/modals/CustomFieldInputs.ts
+++ b/src/modals/CustomFieldInputs.ts
@@ -1,6 +1,7 @@
 import { Menu } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Project, Task, CustomFieldDef } from '../types'
+import { renderChipList } from '../ui/FormField'
 import { stringifyCustomValue } from '../utils'
 
 export function renderCustomFieldInput(
@@ -61,32 +62,29 @@ export function renderCustomFieldInput(
     case 'multiselect': {
       const vals = Array.isArray(currentVal) ? (currentVal as string[]) : []
       const renderMulti = () => {
-        wrap.empty()
-        for (const v of vals) {
-          const chip = wrap.createEl('span', { cls: 'pm-tag pm-tag--removable', text: v })
-          const rm = chip.createEl('button', { text: '\u2715', cls: 'pm-tag-rm' })
-          rm.addEventListener('click', () => {
+        renderChipList(wrap, vals, {
+          shape: 'pill',
+          onRemove: (v) => {
             const idx = vals.indexOf(v)
             if (idx > -1) vals.splice(idx, 1)
             task.customFields[cf.id] = [...vals]
             renderMulti()
-          })
-        }
-        const addBtn = wrap.createEl('button', { text: '+ add', cls: 'pm-prop-add-btn' })
-        addBtn.addEventListener('click', (e) => {
-          const menu = new Menu()
-          for (const opt of cf.options ?? []) {
-            if (!vals.includes(opt)) {
-              menu.addItem((item) =>
-                item.setTitle(opt).onClick(() => {
-                  vals.push(opt)
-                  task.customFields[cf.id] = [...vals]
-                  renderMulti()
-                })
-              )
+          },
+          onAdd: (e) => {
+            const menu = new Menu()
+            for (const opt of cf.options ?? []) {
+              if (!vals.includes(opt)) {
+                menu.addItem((item) =>
+                  item.setTitle(opt).onClick(() => {
+                    vals.push(opt)
+                    task.customFields[cf.id] = [...vals]
+                    renderMulti()
+                  })
+                )
+              }
             }
+            menu.showAtMouseEvent(e)
           }
-          menu.showAtMouseEvent(e)
         })
       }
       renderMulti()

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -1,7 +1,8 @@
 import { App, ButtonComponent, Modal } from 'obsidian'
 import type PMPlugin from '../main'
 import { Project, CustomFieldDef, makeId, makeProject } from '../types'
-import { stringToColor, safeAsync } from '../utils'
+import { safeAsync } from '../utils'
+import { Avatar } from '../ui/primitives/Avatar'
 import { COLOR_DANGER } from '../constants'
 
 const PROJECT_COLORS = [
@@ -147,9 +148,7 @@ export class ProjectModal extends Modal {
       for (let i = 0; i < this.project.teamMembers.length; i++) {
         const row = memberWrap.createDiv('pm-member-row')
         const name = this.project.teamMembers[i] || '?'
-        const avatar = row.createEl('span', { cls: 'pm-avatar' })
-        avatar.textContent = name.slice(0, 2).toUpperCase()
-        avatar.setCssStyles({ background: stringToColor(name) })
+        new Avatar(row).setName(name)
         const input = row.createEl('input', {
           type: 'text',
           value: this.project.teamMembers[i],

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -1,4 +1,4 @@
-import { App, Modal } from 'obsidian'
+import { App, ButtonComponent, Modal } from 'obsidian'
 import type PMPlugin from '../main'
 import { Project, CustomFieldDef, makeId, makeProject } from '../types'
 import { stringToColor, safeAsync } from '../utils'
@@ -213,34 +213,31 @@ export class ProjectModal extends Modal {
     const footer = el.createDiv('pm-modal-footer')
     footer.createDiv('pm-footer-spacer')
 
-    const cancelBtn = footer.createEl('button', { text: 'Cancel', cls: 'pm-btn pm-btn-ghost' })
-    cancelBtn.addEventListener('click', () => this.close())
+    new ButtonComponent(footer).setButtonText('Cancel').onClick(() => this.close())
 
-    const saveBtn = footer.createEl('button', {
-      text: this.isNew ? '+ Create project' : 'Save',
-      cls: 'pm-btn pm-btn-primary'
-    })
-    saveBtn.addEventListener(
-      'click',
-      safeAsync(async () => {
-        const title = titleInput.value.trim()
-        if (!title) {
-          titleInput.addClass('pm-input-error')
-          titleInput.focus()
-          return
-        }
-        this.project.title = title
+    new ButtonComponent(footer)
+      .setButtonText(this.isNew ? '+ Create project' : 'Save')
+      .setCta()
+      .onClick(
+        safeAsync(async () => {
+          const title = titleInput.value.trim()
+          if (!title) {
+            titleInput.addClass('pm-input-error')
+            titleInput.focus()
+            return
+          }
+          this.project.title = title
 
-        if (this.isNew) {
-          this.project.filePath = `${this.plugin.settings.projectsFolder}/${title.replace(/[\\/:*?"<>|]/g, '-')}.md`
-          await this.plugin.store.ensureFolder(this.plugin.settings.projectsFolder)
-        }
+          if (this.isNew) {
+            this.project.filePath = `${this.plugin.settings.projectsFolder}/${title.replace(/[\\/:*?"<>|]/g, '-')}.md`
+            await this.plugin.store.ensureFolder(this.plugin.settings.projectsFolder)
+          }
 
-        await this.plugin.store.saveProject(this.project)
-        await this.onSave(this.project)
-        this.close()
-      })
-    )
+          await this.plugin.store.saveProject(this.project)
+          await this.onSave(this.project)
+          this.close()
+        })
+      )
   }
 
   private renderCustomFieldEditor(

--- a/src/modals/SubtasksPanel.ts
+++ b/src/modals/SubtasksPanel.ts
@@ -1,3 +1,4 @@
+import { ButtonComponent } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Task } from '../types'
 import { makeTask } from '../types'
@@ -11,7 +12,7 @@ export function renderSubtasksPanel(container: HTMLElement, task: Task, plugin: 
   const subSection = container.createDiv('pm-modal-section')
   const subHeader = subSection.createDiv('pm-modal-section-header')
   subHeader.createEl('h4', { text: `Subtasks (${task.subtasks.length})`, cls: 'pm-modal-section-title' })
-  const addSubBtn = subHeader.createEl('button', { text: '+ add', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
+  const addSubBtn = new ButtonComponent(subHeader).setButtonText('+ add')
 
   const subList = subSection.createDiv('pm-modal-subtask-list')
   const renderSubtasks = () => {
@@ -47,7 +48,7 @@ export function renderSubtasksPanel(container: HTMLElement, task: Task, plugin: 
   }
   renderSubtasks()
 
-  addSubBtn.addEventListener('click', () => {
+  addSubBtn.onClick(() => {
     const newSub = makeTask({ title: 'New subtask' })
     task.subtasks.push(newSub)
     renderSubtasks()

--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -4,6 +4,7 @@ import { Project, Task, TaskType, Recurrence } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
 import { wouldCreateCycle } from '../store/Scheduler'
 import { renderPropRow, renderProgressSlider, renderChipList } from '../ui/FormField'
+import { Badge } from '../ui/primitives/Badge'
 import { COLOR_MUTED } from '../constants'
 import { getStatusConfig, getPriorityConfig, formatBadgeText } from '../utils'
 import { renderCustomFieldInput } from './CustomFieldInputs'
@@ -28,49 +29,51 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
   // Status
   renderPropRow(container, 'Status', () => {
     const statusConfig = getStatusConfig(plugin.settings.statuses, task.status)
-    const val = createEl('button', { cls: 'pm-prop-value pm-prop-value--badge' })
-    val.setCssProps({ '--badge-color': statusConfig?.color ?? COLOR_MUTED })
-    val.setText(formatBadgeText(statusConfig?.icon, statusConfig?.label ?? task.status))
-    val.addEventListener('click', (e) => {
-      const menu = new Menu()
-      for (const s of plugin.settings.statuses) {
-        menu.addItem((item) =>
-          item
-            .setTitle(formatBadgeText(s.icon, s.label))
-            .setChecked(s.id === task.status)
-            .onClick(() => {
-              task.status = s.id
-              rerender()
-            })
-        )
-      }
-      menu.showAtMouseEvent(e)
-    })
-    return val
+    const wrap = createDiv('pm-prop-value')
+    new Badge(wrap)
+      .setLabel(formatBadgeText(statusConfig?.icon, statusConfig?.label ?? task.status))
+      .setColor(statusConfig?.color ?? COLOR_MUTED)
+      .onClick((e) => {
+        const menu = new Menu()
+        for (const s of plugin.settings.statuses) {
+          menu.addItem((item) =>
+            item
+              .setTitle(formatBadgeText(s.icon, s.label))
+              .setChecked(s.id === task.status)
+              .onClick(() => {
+                task.status = s.id
+                rerender()
+              })
+          )
+        }
+        menu.showAtMouseEvent(e)
+      })
+    return wrap
   })
 
   // Priority
   renderPropRow(container, 'Priority', () => {
     const prioConfig = getPriorityConfig(plugin.settings.priorities, task.priority)
-    const val = createEl('button', { cls: 'pm-prop-value pm-prop-value--badge' })
-    val.setCssProps({ '--badge-color': prioConfig?.color ?? COLOR_MUTED })
-    val.setText(formatBadgeText(prioConfig?.icon, prioConfig?.label ?? task.priority))
-    val.addEventListener('click', (e) => {
-      const menu = new Menu()
-      for (const p of plugin.settings.priorities) {
-        menu.addItem((item) =>
-          item
-            .setTitle(formatBadgeText(p.icon, p.label))
-            .setChecked(p.id === task.priority)
-            .onClick(() => {
-              task.priority = p.id
-              rerender()
-            })
-        )
-      }
-      menu.showAtMouseEvent(e)
-    })
-    return val
+    const wrap = createDiv('pm-prop-value')
+    new Badge(wrap)
+      .setLabel(formatBadgeText(prioConfig?.icon, prioConfig?.label ?? task.priority))
+      .setColor(prioConfig?.color ?? COLOR_MUTED)
+      .onClick((e) => {
+        const menu = new Menu()
+        for (const p of plugin.settings.priorities) {
+          menu.addItem((item) =>
+            item
+              .setTitle(formatBadgeText(p.icon, p.label))
+              .setChecked(p.id === task.priority)
+              .onClick(() => {
+                task.priority = p.id
+                rerender()
+              })
+          )
+        }
+        menu.showAtMouseEvent(e)
+      })
+    return wrap
   })
 
   // Type

--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -212,8 +212,8 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
       const all = [...new Set([...project.teamMembers, ...plugin.settings.globalTeamMembers])]
       const remaining = all.filter((m) => !task.assignees.includes(m))
       renderChipList(wrap, task.assignees, {
-        chipCls: 'pm-assignee-chip',
-        rmCls: 'pm-assignee-chip-rm',
+        variant: 'accent',
+        shape: 'pill',
         onRemove: (a) => {
           task.assignees = task.assignees.filter((x) => x !== a)
           render()
@@ -268,8 +268,7 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
         (t) => !task.tags.includes(t)
       )
       renderChipList(wrap, task.tags, {
-        chipCls: 'pm-tag pm-tag--removable',
-        rmCls: 'pm-tag-rm',
+        shape: 'pill',
         onRemove: (tag) => {
           task.tags = task.tags.filter((x) => x !== tag)
           render()
@@ -300,8 +299,7 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
         wrap,
         task.dependencies.filter((id) => allTasks.some((t) => t.id === id)),
         {
-          chipCls: 'pm-dep-chip',
-          rmCls: 'pm-dep-chip-rm',
+          shape: 'rounded',
           labelFn: (depId) => allTasks.find((t) => t.id === depId)?.title ?? depId,
           onRemove: (depId) => {
             task.dependencies = task.dependencies.filter((x) => x !== depId)

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -1,4 +1,4 @@
-import { App, Component, Modal, MarkdownRenderer, Notice } from 'obsidian'
+import { App, ButtonComponent, Component, Modal, MarkdownRenderer, Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import { Project, Task, makeTask } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
@@ -271,12 +271,7 @@ export class TaskModal extends Modal {
 
     if (!this.isNew) {
       if (this.task.archived) {
-        const unarchiveBtn = footer.createEl('button', {
-          text: 'Unarchive',
-          cls: 'pm-btn pm-btn-ghost'
-        })
-        unarchiveBtn.addEventListener(
-          'click',
+        new ButtonComponent(footer).setButtonText('Unarchive').onClick(
           safeAsync(async () => {
             await this.plugin.store.unarchiveTask(this.project, this.task.id)
             new Notice('Task unarchived')
@@ -286,12 +281,7 @@ export class TaskModal extends Modal {
           })
         )
       } else {
-        const archiveBtn = footer.createEl('button', {
-          text: 'Archive',
-          cls: 'pm-btn pm-btn-ghost'
-        })
-        archiveBtn.addEventListener(
-          'click',
+        new ButtonComponent(footer).setButtonText('Archive').onClick(
           safeAsync(async () => {
             await this.plugin.store.archiveTask(this.project, this.task.id)
             new Notice('Task archived')
@@ -302,32 +292,31 @@ export class TaskModal extends Modal {
         )
       }
 
-      const deleteBtn = footer.createEl('button', { text: 'Delete', cls: 'pm-btn pm-btn-danger' })
-      deleteBtn.addEventListener(
-        'click',
-        safeAsync(async () => {
-          if (await confirmDialog(this.app, `Delete "${this.task.title}"?`)) {
-            await this.plugin.store.deleteTask(this.project, this.task.id)
-            await this.onSave(this.task)
-            this.cancelled = true
-            this.close()
-          }
-        })
-      )
+      new ButtonComponent(footer)
+        .setButtonText('Delete')
+        .setWarning()
+        .onClick(
+          safeAsync(async () => {
+            if (await confirmDialog(this.app, `Delete "${this.task.title}"?`)) {
+              await this.plugin.store.deleteTask(this.project, this.task.id)
+              await this.onSave(this.task)
+              this.cancelled = true
+              this.close()
+            }
+          })
+        )
     }
 
     footer.createDiv('pm-footer-spacer')
 
-    const cancelBtn = footer.createEl('button', { text: 'Cancel', cls: 'pm-btn pm-btn-ghost' })
-    cancelBtn.addEventListener('click', () => {
+    new ButtonComponent(footer).setButtonText('Cancel').onClick(() => {
       this.cancelled = true
       this.close()
     })
 
-    const saveBtn = footer.createEl('button', {
-      text: this.isNew ? 'Create (Shift+Enter)' : 'Save (Shift+Enter)',
-      cls: 'pm-btn pm-btn-primary'
-    })
+    const saveBtn = new ButtonComponent(footer)
+      .setButtonText(this.isNew ? 'Create (Shift+Enter)' : 'Save (Shift+Enter)')
+      .setCta()
     let saving = false
     const doSave = safeAsync(async () => {
       if (saving) return
@@ -343,7 +332,7 @@ export class TaskModal extends Modal {
       this.close()
     })
 
-    saveBtn.addEventListener('click', doSave)
+    saveBtn.onClick(doSave)
     this.modalEl.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault()

--- a/src/ui/FilterDropdown.ts
+++ b/src/ui/FilterDropdown.ts
@@ -1,10 +1,6 @@
 import { Menu } from 'obsidian'
 import { Pill } from './primitives/Pill'
 
-/**
- * Render a filter dropdown pill that opens a multi-select menu.
- * Used in TableView's filter bar for status, priority, assignee, tag filters.
- */
 export function renderFilterDropdown(
   parent: HTMLElement,
   label: string,
@@ -44,6 +40,6 @@ export function renderFilterDropdown(
       menu.showAtMouseEvent(e)
     })
 
-  pill.buttonEl.setAttribute('role', 'combobox')
-  return pill.buttonEl
+  pill.el.setAttribute('role', 'combobox')
+  return pill.el
 }

--- a/src/ui/FilterDropdown.ts
+++ b/src/ui/FilterDropdown.ts
@@ -1,7 +1,8 @@
 import { Menu } from 'obsidian'
+import { Pill } from './primitives/Pill'
 
 /**
- * Render a filter dropdown button that opens a multi-select menu.
+ * Render a filter dropdown pill that opens a multi-select menu.
  * Used in TableView's filter bar for status, priority, assignee, tag filters.
  */
 export function renderFilterDropdown(
@@ -12,39 +13,37 @@ export function renderFilterDropdown(
   onChange: (selected: string[]) => void
 ): HTMLElement {
   const hasSelection = selected.length > 0
-  const btn = parent.createEl('button', {
-    text: hasSelection ? `${label}: ${selected.length}` : label,
-    cls: 'pm-filter-dropdown-btn',
-    attr: { 'aria-label': `Filter by ${label}`, role: 'combobox' }
-  })
-  if (hasSelection) btn.addClass('pm-filter-dropdown-btn--active')
-
-  btn.addEventListener('click', (e) => {
-    const menu = new Menu()
-    for (const opt of options) {
-      menu.addItem((item) =>
-        item
-          .setTitle(opt.label)
-          .setChecked(selected.includes(opt.id))
-          .onClick(() => {
-            const idx = selected.indexOf(opt.id)
-            if (idx >= 0) selected.splice(idx, 1)
-            else selected.push(opt.id)
+  const pill = new Pill(parent)
+    .setLabel(hasSelection ? `${label}: ${selected.length}` : label)
+    .setActive(hasSelection)
+    .setAriaLabel(`Filter by ${label}`)
+    .onClick((e) => {
+      const menu = new Menu()
+      for (const opt of options) {
+        menu.addItem((item) =>
+          item
+            .setTitle(opt.label)
+            .setChecked(selected.includes(opt.id))
+            .onClick(() => {
+              const idx = selected.indexOf(opt.id)
+              if (idx >= 0) selected.splice(idx, 1)
+              else selected.push(opt.id)
+              onChange(selected)
+            })
+        )
+      }
+      if (selected.length) {
+        menu.addSeparator()
+        menu.addItem((item) =>
+          item.setTitle('Clear').onClick(() => {
+            selected.length = 0
             onChange(selected)
           })
-      )
-    }
-    if (selected.length) {
-      menu.addSeparator()
-      menu.addItem((item) =>
-        item.setTitle('Clear').onClick(() => {
-          selected.length = 0
-          onChange(selected)
-        })
-      )
-    }
-    menu.showAtMouseEvent(e)
-  })
+        )
+      }
+      menu.showAtMouseEvent(e)
+    })
 
-  return btn
+  pill.buttonEl.setAttribute('role', 'combobox')
+  return pill.buttonEl
 }

--- a/src/ui/FormField.ts
+++ b/src/ui/FormField.ts
@@ -1,9 +1,6 @@
 import { ButtonComponent } from 'obsidian'
 import { Chip } from './primitives/Chip'
 
-/**
- * Render a labeled property row (label + value) used in modals.
- */
 export function renderPropRow(container: HTMLElement, label: string, valueBuilder: () => HTMLElement): HTMLElement {
   const row = container.createDiv('pm-prop-row')
   row.createEl('span', { text: label, cls: 'pm-prop-label' })
@@ -22,10 +19,6 @@ export interface ChipListOpts {
   renderAdd?: (container: HTMLElement) => void
 }
 
-/**
- * Render a chip list with remove buttons and an add button.
- * Used for assignees, tags, dependencies, etc.
- */
 export function renderChipList(container: HTMLElement, items: string[], opts: ChipListOpts): void {
   container.empty()
   const variant = opts.variant ?? 'default'
@@ -44,9 +37,6 @@ export function renderChipList(container: HTMLElement, items: string[], opts: Ch
   }
 }
 
-/**
- * Render a progress slider with label.
- */
 export function renderProgressSlider(
   container: HTMLElement,
   value: number,

--- a/src/ui/FormField.ts
+++ b/src/ui/FormField.ts
@@ -1,3 +1,6 @@
+import { ButtonComponent } from 'obsidian'
+import { Chip } from './primitives/Chip'
+
 /**
  * Render a labeled property row (label + value) used in modals.
  */
@@ -9,35 +12,35 @@ export function renderPropRow(container: HTMLElement, label: string, valueBuilde
   return row
 }
 
+export interface ChipListOpts {
+  variant?: 'default' | 'accent'
+  shape?: 'rounded' | 'pill'
+  onRemove: (item: string) => void
+  labelFn?: (item: string) => string
+  onAdd?: (e: MouseEvent) => void
+  addLabel?: string
+  renderAdd?: (container: HTMLElement) => void
+}
+
 /**
  * Render a chip list with remove buttons and an add button.
  * Used for assignees, tags, dependencies, etc.
  */
-export function renderChipList(
-  container: HTMLElement,
-  items: string[],
-  opts: {
-    chipCls: string
-    rmCls: string
-    onRemove: (item: string) => void
-    labelFn?: (item: string) => string
-    onAdd?: (e: MouseEvent) => void
-    addLabel?: string
-    renderAdd?: (container: HTMLElement) => void
-  }
-): void {
+export function renderChipList(container: HTMLElement, items: string[], opts: ChipListOpts): void {
   container.empty()
+  const variant = opts.variant ?? 'default'
+  const shape = opts.shape ?? 'pill'
   for (const item of items) {
-    const chip = container.createEl('span', { cls: opts.chipCls })
-    chip.setText(opts.labelFn ? opts.labelFn(item) : item)
-    const rm = chip.createEl('button', { text: '\u2715', cls: opts.rmCls })
-    rm.addEventListener('click', () => opts.onRemove(item))
+    new Chip(container)
+      .setLabel(opts.labelFn ? opts.labelFn(item) : item)
+      .setVariant(variant)
+      .setShape(shape)
+      .setRemovable(() => opts.onRemove(item))
   }
   if (opts.renderAdd) {
     opts.renderAdd(container)
   } else if (opts.onAdd) {
-    const addBtn = container.createEl('button', { text: opts.addLabel ?? '+ Add', cls: 'pm-prop-add-btn' })
-    addBtn.addEventListener('click', (e) => opts.onAdd!(e))
+    new ButtonComponent(container).setButtonText(opts.addLabel ?? '+ Add').onClick((e) => opts.onAdd!(e))
   }
 }
 

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -1,4 +1,4 @@
-import { type App, Modal } from 'obsidian'
+import { type App, ButtonComponent, Modal } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Project, Task } from '../types'
 import { TaskModal } from '../modals/TaskModal'
@@ -74,23 +74,23 @@ class TextPromptModal extends Modal {
 
     const btnRow = contentEl.createDiv('pm-modal-btn-row')
 
-    const cancelBtn = btnRow.createEl('button', { text: 'Cancel', cls: 'mod-muted' })
-    cancelBtn.addEventListener('click', () => {
+    new ButtonComponent(btnRow).setButtonText('Cancel').onClick(() => {
       this.finish(null)
       this.close()
     })
 
-    const okBtn = btnRow.createEl('button', { text: 'OK', cls: 'mod-cta' })
-    okBtn.addEventListener('click', () => {
+    const submit = () => {
       const val = input.value.trim()
       this.finish(val || null)
       this.close()
-    })
+    }
+
+    new ButtonComponent(btnRow).setButtonText('OK').setCta().onClick(submit)
 
     input.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {
         e.preventDefault()
-        okBtn.click()
+        submit()
       }
       if (e.key === 'Escape') {
         e.preventDefault()
@@ -137,17 +137,18 @@ class ConfirmModal extends Modal {
 
     const btnRow = contentEl.createDiv('pm-modal-btn-row')
 
-    const cancelBtn = btnRow.createEl('button', { text: 'Cancel', cls: 'mod-muted' })
-    cancelBtn.addEventListener('click', () => {
+    new ButtonComponent(btnRow).setButtonText('Cancel').onClick(() => {
       this.finish(false)
       this.close()
     })
 
-    const confirmBtn = btnRow.createEl('button', { text: this.confirmLabel, cls: 'mod-warning pm-btn-confirm-danger' })
-    confirmBtn.addEventListener('click', () => {
-      this.finish(true)
-      this.close()
-    })
+    new ButtonComponent(btnRow)
+      .setButtonText(this.confirmLabel)
+      .setWarning()
+      .onClick(() => {
+        this.finish(true)
+        this.close()
+      })
   }
 
   onClose(): void {
@@ -184,23 +185,23 @@ class DuplicateSubtasksModal extends Modal {
 
     const btnRow = contentEl.createDiv('pm-modal-btn-row')
 
-    const cancelBtn = btnRow.createEl('button', { text: 'Cancel', cls: 'mod-muted' })
-    cancelBtn.addEventListener('click', () => {
+    new ButtonComponent(btnRow).setButtonText('Cancel').onClick(() => {
       this.finish(null)
       this.close()
     })
 
-    const taskOnlyBtn = btnRow.createEl('button', { text: 'Task only' })
-    taskOnlyBtn.addEventListener('click', () => {
+    new ButtonComponent(btnRow).setButtonText('Task only').onClick(() => {
       this.finish('task-only')
       this.close()
     })
 
-    const withSubtasksBtn = btnRow.createEl('button', { text: 'With subtasks', cls: 'mod-cta' })
-    withSubtasksBtn.addEventListener('click', () => {
-      this.finish('with-subtasks')
-      this.close()
-    })
+    new ButtonComponent(btnRow)
+      .setButtonText('With subtasks')
+      .setCta()
+      .onClick(() => {
+        this.finish('with-subtasks')
+        this.close()
+      })
   }
 
   onClose(): void {

--- a/src/ui/StatusBadge.ts
+++ b/src/ui/StatusBadge.ts
@@ -2,6 +2,7 @@ import { Menu } from 'obsidian'
 import type { Task, TaskStatus, TaskPriority, StatusConfig, PriorityConfig } from '../types'
 import { COLOR_MUTED, COLOR_MUTED_ALT } from '../constants'
 import { getStatusConfig, getPriorityConfig, formatBadgeText } from '../utils'
+import { Badge } from './primitives/Badge'
 
 /**
  * Render a clickable status badge that opens a menu to change the status.
@@ -13,24 +14,22 @@ export function renderStatusBadge(
   onChange: (status: TaskStatus) => void
 ): HTMLElement {
   const config = getStatusConfig(statuses, task.status)
-  const badge = container.createEl('span', {
-    text: formatBadgeText(config?.icon, config?.label ?? task.status),
-    cls: 'pm-status-badge'
-  })
-  badge.style.setProperty('--badge-color', config?.color ?? COLOR_MUTED)
-  badge.addEventListener('click', (e) => {
-    const menu = new Menu()
-    for (const s of statuses) {
-      menu.addItem((item) =>
-        item
-          .setTitle(formatBadgeText(s.icon, s.label))
-          .setChecked(s.id === task.status)
-          .onClick(() => onChange(s.id))
-      )
-    }
-    menu.showAtMouseEvent(e)
-  })
-  return badge
+  const badge = new Badge(container)
+    .setLabel(formatBadgeText(config?.icon, config?.label ?? task.status))
+    .setColor(config?.color ?? COLOR_MUTED)
+    .onClick((e) => {
+      const menu = new Menu()
+      for (const s of statuses) {
+        menu.addItem((item) =>
+          item
+            .setTitle(formatBadgeText(s.icon, s.label))
+            .setChecked(s.id === task.status)
+            .onClick(() => onChange(s.id))
+        )
+      }
+      menu.showAtMouseEvent(e)
+    })
+  return badge.el
 }
 
 /**
@@ -43,24 +42,22 @@ export function renderPriorityBadge(
   onChange: (priority: TaskPriority) => void
 ): HTMLElement {
   const config = getPriorityConfig(priorities, task.priority)
-  const badge = container.createEl('span', {
-    text: formatBadgeText(config?.icon, config?.label ?? task.priority),
-    cls: 'pm-priority-badge'
-  })
-  badge.style.setProperty('--badge-color', config?.color ?? COLOR_MUTED_ALT)
-  badge.addEventListener('click', (e) => {
-    const menu = new Menu()
-    for (const p of priorities) {
-      menu.addItem((item) =>
-        item
-          .setTitle(formatBadgeText(p.icon, p.label))
-          .setChecked(p.id === task.priority)
-          .onClick(() => onChange(p.id))
-      )
-    }
-    menu.showAtMouseEvent(e)
-  })
-  return badge
+  const badge = new Badge(container)
+    .setLabel(formatBadgeText(config?.icon, config?.label ?? task.priority))
+    .setColor(config?.color ?? COLOR_MUTED_ALT)
+    .onClick((e) => {
+      const menu = new Menu()
+      for (const p of priorities) {
+        menu.addItem((item) =>
+          item
+            .setTitle(formatBadgeText(p.icon, p.label))
+            .setChecked(p.id === task.priority)
+            .onClick(() => onChange(p.id))
+        )
+      }
+      menu.showAtMouseEvent(e)
+    })
+  return badge.el
 }
 
 /**

--- a/src/ui/StatusBadge.ts
+++ b/src/ui/StatusBadge.ts
@@ -4,9 +4,6 @@ import { COLOR_MUTED, COLOR_MUTED_ALT } from '../constants'
 import { getStatusConfig, getPriorityConfig, formatBadgeText } from '../utils'
 import { Badge } from './primitives/Badge'
 
-/**
- * Render a clickable status badge that opens a menu to change the status.
- */
 export function renderStatusBadge(
   container: HTMLElement,
   task: Task,
@@ -32,9 +29,6 @@ export function renderStatusBadge(
   return badge.el
 }
 
-/**
- * Render a clickable priority badge that opens a menu to change the priority.
- */
 export function renderPriorityBadge(
   container: HTMLElement,
   task: Task,
@@ -60,9 +54,6 @@ export function renderPriorityBadge(
   return badge.el
 }
 
-/**
- * Render a simple status dot (colored circle).
- */
 export function renderStatusDot(
   container: HTMLElement,
   status: TaskStatus,

--- a/src/ui/composites/KanbanCard.ts
+++ b/src/ui/composites/KanbanCard.ts
@@ -1,0 +1,110 @@
+import type { Task } from '../../types'
+import { formatDateShort } from '../../utils'
+import { AvatarStack } from '../primitives/AvatarStack'
+import { Badge } from '../primitives/Badge'
+import { Chip } from '../primitives/Chip'
+import { DueDateChip } from '../primitives/DueDateChip'
+import { ProgressBar } from '../primitives/ProgressBar'
+
+export interface KanbanCardProps {
+  task: Task
+  priorityColor?: string
+  parentTitle?: string
+  subtaskProgress?: { done: number; total: number }
+  loggedHours: number
+  overdue: boolean
+  onClick: () => void
+  onContextMenu: (e: MouseEvent) => void
+  onDragStart: () => void
+  onDragEnd: () => void
+}
+
+export class KanbanCard {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement, props: KanbanCardProps) {
+    const { task } = props
+    const card = parentEl.createDiv('pm-kanban-card')
+    card.draggable = true
+    card.dataset.taskId = task.id
+    this.el = card
+
+    if (props.priorityColor) {
+      const priorityBar = card.createDiv('pm-kanban-card-priority-bar')
+      priorityBar.setCssStyles({ background: props.priorityColor })
+    }
+
+    const body = card.createDiv('pm-kanban-card-body')
+
+    if (props.parentTitle) {
+      body.createEl('span', { text: props.parentTitle, cls: 'pm-kanban-card-parent' })
+    }
+
+    const titleRow = body.createDiv('pm-kanban-card-title-row')
+    titleRow.createEl('span', { text: task.title, cls: 'pm-kanban-card-title' })
+    if (task.type === 'milestone') {
+      new Badge(titleRow).setLabel('M').setSize('sm').setColor('var(--color-purple)').setTooltip('Milestone')
+    }
+    if (task.type === 'subtask') {
+      new Badge(titleRow).setLabel('Sub').setSize('sm').setColor('var(--color-green)').setTooltip('Subtask')
+    }
+    if (task.recurrence) {
+      new Badge(titleRow).setLabel('R').setSize('sm').setColor('var(--color-blue)').setTooltip('Recurring')
+    }
+
+    const est = task.timeEstimate ?? 0
+    if (props.loggedHours > 0 || est > 0) {
+      const timeBadge = body.createEl('span', { cls: 'pm-time-chip pm-time-chip--sm' })
+      timeBadge.setText(est > 0 ? `${props.loggedHours}/${est}h` : `${props.loggedHours}h`)
+      if (est > 0 && props.loggedHours > est) timeBadge.addClass('pm-time-chip--over')
+    }
+
+    if (task.tags.length) {
+      const tagsEl = body.createDiv('pm-kanban-card-tags')
+      for (const tag of task.tags.slice(0, 3)) {
+        new Chip(tagsEl).setLabel(tag).setShape('pill').setSize('sm')
+      }
+    }
+
+    const footer = body.createDiv('pm-kanban-card-footer')
+    new AvatarStack(footer).setNames(task.assignees).setMax(3).setSize('sm')
+
+    if (task.due) {
+      new DueDateChip(footer)
+        .setVariant('label')
+        .setLabel(formatDateShort(task.due))
+        .setUrgency(props.overdue ? 'overdue' : 'normal')
+    }
+
+    if (task.progress > 0) {
+      new ProgressBar(body).setSize('sm').setValue(task.progress)
+    }
+
+    if (props.subtaskProgress) {
+      const { done, total } = props.subtaskProgress
+      body.createEl('span', {
+        text: `${done}/${total} subtasks`,
+        cls: 'pm-kanban-card-subtasks'
+      })
+    }
+
+    card.addEventListener('dragstart', (e) => {
+      e.dataTransfer?.setData('text/plain', task.id)
+      card.addClass('pm-kanban-card--dragging')
+      activeWindow.setTimeout(() => card.addClass('pm-dragging'), 0)
+      props.onDragStart()
+    })
+
+    card.addEventListener('dragend', () => {
+      card.removeClass('pm-kanban-card--dragging')
+      card.removeClass('pm-dragging')
+      props.onDragEnd()
+    })
+
+    card.addEventListener('click', () => props.onClick())
+    card.addEventListener('contextmenu', (e) => {
+      e.preventDefault()
+      props.onContextMenu(e)
+    })
+  }
+}

--- a/src/ui/composites/KanbanColumn.ts
+++ b/src/ui/composites/KanbanColumn.ts
@@ -1,0 +1,120 @@
+import type { Task } from '../../types'
+import { formatBadgeText, safeAsync } from '../../utils'
+import { KanbanCard } from './KanbanCard'
+
+export interface KanbanColumnStatus {
+  id: string
+  label: string
+  color: string
+  icon: string
+}
+
+export interface KanbanCardData {
+  task: Task
+  priorityColor?: string
+  parentTitle?: string
+  subtaskProgress?: { done: number; total: number }
+  loggedHours: number
+  overdue: boolean
+}
+
+export interface KanbanColumnProps {
+  status: KanbanColumnStatus
+  cards: KanbanCardData[]
+  onCardClick: (task: Task) => void
+  onCardContextMenu: (task: Task, e: MouseEvent) => void
+  onCardDragStart: (task: Task) => void
+  onCardDragEnd: () => void
+  onDrop: (taskId: string, newStatus: string) => Promise<void>
+}
+
+export class KanbanColumn {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement, props: KanbanColumnProps) {
+    const col = parentEl.createDiv('pm-kanban-col')
+    col.dataset.status = props.status.id
+    this.el = col
+
+    const header = col.createDiv('pm-kanban-col-header')
+    header.style.setProperty('--col-color', props.status.color)
+
+    const topBar = header.createDiv('pm-kanban-col-topbar')
+    topBar.setCssStyles({ background: props.status.color })
+
+    const titleRow = header.createDiv('pm-kanban-col-title-row')
+    const badge = titleRow.createEl('span', {
+      text: formatBadgeText(props.status.icon, props.status.label),
+      cls: 'pm-kanban-col-badge'
+    })
+    badge.style.color = props.status.color
+
+    const headerRight = titleRow.createDiv('pm-kanban-col-header-right')
+    headerRight.createEl('span', {
+      text: String(props.cards.length),
+      cls: 'pm-kanban-col-count'
+    })
+
+    const cardsEl = col.createDiv('pm-kanban-cards')
+    cardsEl.dataset.status = props.status.id
+
+    for (const card of props.cards) {
+      new KanbanCard(cardsEl, {
+        task: card.task,
+        priorityColor: card.priorityColor,
+        parentTitle: card.parentTitle,
+        subtaskProgress: card.subtaskProgress,
+        loggedHours: card.loggedHours,
+        overdue: card.overdue,
+        onClick: () => props.onCardClick(card.task),
+        onContextMenu: (e) => props.onCardContextMenu(card.task, e),
+        onDragStart: () => props.onCardDragStart(card.task),
+        onDragEnd: () => props.onCardDragEnd()
+      })
+    }
+
+    cardsEl.addEventListener('dragover', (e) => {
+      e.preventDefault()
+      cardsEl.addClass('pm-kanban-drop-target')
+      const afterEl = getDragAfterElement(cardsEl, e.clientY)
+      const dragging = cardsEl.querySelector('.pm-kanban-card--dragging')
+      if (dragging) {
+        if (afterEl) {
+          cardsEl.insertBefore(dragging, afterEl)
+        } else {
+          cardsEl.appendChild(dragging)
+        }
+      }
+    })
+
+    cardsEl.addEventListener('dragleave', () => {
+      cardsEl.removeClass('pm-kanban-drop-target')
+    })
+
+    cardsEl.addEventListener(
+      'drop',
+      safeAsync(async (e: DragEvent) => {
+        e.preventDefault()
+        cardsEl.removeClass('pm-kanban-drop-target')
+        const taskId = e.dataTransfer?.getData('text/plain') ?? ''
+        if (!taskId) return
+        await props.onDrop(taskId, props.status.id)
+      })
+    )
+  }
+}
+
+function getDragAfterElement(container: HTMLElement, y: number): Element | null {
+  const cards = Array.from(container.querySelectorAll('.pm-kanban-card:not(.pm-kanban-card--dragging)'))
+  let closest: Element | null = null
+  let closestOffset = Number.NEGATIVE_INFINITY
+  for (const card of cards) {
+    const box = card.getBoundingClientRect()
+    const offset = y - box.top - box.height / 2
+    if (offset < 0 && offset > closestOffset) {
+      closestOffset = offset
+      closest = card
+    }
+  }
+  return closest
+}

--- a/src/ui/primitives/Avatar.ts
+++ b/src/ui/primitives/Avatar.ts
@@ -1,3 +1,4 @@
+import { setTooltip } from 'obsidian'
 import { stringToColor } from '../../utils'
 
 export class Avatar {
@@ -10,7 +11,7 @@ export class Avatar {
   setName(name: string): this {
     this.el.setText(name.slice(0, 2).toUpperCase())
     this.el.style.background = stringToColor(name)
-    this.el.setAttribute('title', name)
+    setTooltip(this.el, name)
     return this
   }
 

--- a/src/ui/primitives/Avatar.ts
+++ b/src/ui/primitives/Avatar.ts
@@ -1,0 +1,21 @@
+import { stringToColor } from '../../utils'
+
+export class Avatar {
+  el: HTMLSpanElement
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createEl('span', { cls: 'pm-avatar' })
+  }
+
+  setName(name: string): this {
+    this.el.setText(name.slice(0, 2).toUpperCase())
+    this.el.style.background = stringToColor(name)
+    this.el.setAttribute('title', name)
+    return this
+  }
+
+  setSize(size: 'md' | 'sm'): this {
+    this.el.toggleClass('pm-avatar--sm', size === 'sm')
+    return this
+  }
+}

--- a/src/ui/primitives/AvatarStack.ts
+++ b/src/ui/primitives/AvatarStack.ts
@@ -1,0 +1,44 @@
+import { Avatar } from './Avatar'
+
+export class AvatarStack {
+  el: HTMLElement
+  private names: string[] = []
+  private max = 3
+  private size: 'md' | 'sm' = 'md'
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createDiv('pm-avatar-stack')
+  }
+
+  setNames(names: string[]): this {
+    this.names = names
+    this.render()
+    return this
+  }
+
+  setMax(max: number): this {
+    this.max = max
+    this.render()
+    return this
+  }
+
+  setSize(size: 'md' | 'sm'): this {
+    this.size = size
+    this.render()
+    return this
+  }
+
+  private render(): void {
+    this.el.empty()
+    const visible = this.names.slice(0, this.max)
+    for (const name of visible) {
+      new Avatar(this.el).setName(name).setSize(this.size)
+    }
+    const overflow = this.names.length - visible.length
+    if (overflow > 0) {
+      const more = this.el.createEl('span', { cls: 'pm-avatar pm-avatar--more' })
+      more.setText(`+${overflow}`)
+      if (this.size === 'sm') more.addClass('pm-avatar--sm')
+    }
+  }
+}

--- a/src/ui/primitives/Badge.ts
+++ b/src/ui/primitives/Badge.ts
@@ -1,0 +1,33 @@
+export class Badge {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createEl('span', { cls: 'pm-badge' })
+  }
+
+  setLabel(text: string): this {
+    this.el.setText(text)
+    return this
+  }
+
+  setColor(color: string): this {
+    this.el.style.setProperty('--pm-badge-color', color)
+    return this
+  }
+
+  setSize(size: 'md' | 'sm'): this {
+    this.el.toggleClass('pm-badge--sm', size === 'sm')
+    return this
+  }
+
+  setTooltip(text: string): this {
+    this.el.setAttribute('title', text)
+    return this
+  }
+
+  onClick(callback: (e: MouseEvent) => unknown): this {
+    this.el.addClass('pm-badge--interactive')
+    this.el.addEventListener('click', callback)
+    return this
+  }
+}

--- a/src/ui/primitives/Badge.ts
+++ b/src/ui/primitives/Badge.ts
@@ -27,9 +27,9 @@ export class Badge {
     return this
   }
 
-  onClick(callback: (e: MouseEvent) => unknown): this {
+  onClick(handler: (e: MouseEvent) => unknown): this {
     this.el.addClass('pm-badge--interactive')
-    this.el.addEventListener('click', callback)
+    this.el.addEventListener('click', handler)
     return this
   }
 }

--- a/src/ui/primitives/Badge.ts
+++ b/src/ui/primitives/Badge.ts
@@ -1,3 +1,5 @@
+import { setTooltip } from 'obsidian'
+
 export class Badge {
   el: HTMLElement
 
@@ -21,7 +23,7 @@ export class Badge {
   }
 
   setTooltip(text: string): this {
-    this.el.setAttribute('title', text)
+    setTooltip(this.el, text)
     return this
   }
 

--- a/src/ui/primitives/Chip.ts
+++ b/src/ui/primitives/Chip.ts
@@ -1,13 +1,12 @@
-import { setIcon } from 'obsidian'
+import { setIcon, setTooltip } from 'obsidian'
 
 export class Chip {
   el: HTMLElement
   private labelEl: HTMLElement
-  private rmBtn: HTMLButtonElement | null = null
 
   constructor(parentEl: HTMLElement) {
     this.el = parentEl.createEl('span', { cls: 'pm-chip' })
-    this.labelEl = this.el.createEl('span', { cls: 'pm-chip-label' })
+    this.labelEl = this.el.createSpan()
   }
 
   setLabel(text: string): this {
@@ -31,16 +30,14 @@ export class Chip {
   }
 
   setTooltip(text: string): this {
-    this.el.setAttribute('title', text)
+    setTooltip(this.el, text)
     return this
   }
 
   setRemovable(onRemove: () => void): this {
-    if (!this.rmBtn) {
-      this.rmBtn = this.el.createEl('button', { cls: 'pm-chip-rm' })
-      setIcon(this.rmBtn, 'x')
-    }
-    this.rmBtn.onclick = (e) => {
+    const rmBtn = this.el.createEl('button', { cls: 'pm-chip-rm' })
+    setIcon(rmBtn, 'x')
+    rmBtn.onclick = (e) => {
       e.preventDefault()
       e.stopPropagation()
       onRemove()

--- a/src/ui/primitives/Chip.ts
+++ b/src/ui/primitives/Chip.ts
@@ -1,0 +1,50 @@
+import { setIcon } from 'obsidian'
+
+export class Chip {
+  el: HTMLElement
+  private labelEl: HTMLElement
+  private rmBtn: HTMLButtonElement | null = null
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createEl('span', { cls: 'pm-chip' })
+    this.labelEl = this.el.createEl('span', { cls: 'pm-chip-label' })
+  }
+
+  setLabel(text: string): this {
+    this.labelEl.setText(text)
+    return this
+  }
+
+  setVariant(variant: 'default' | 'accent'): this {
+    this.el.toggleClass('pm-chip--accent', variant === 'accent')
+    return this
+  }
+
+  setShape(shape: 'rounded' | 'pill'): this {
+    this.el.toggleClass('pm-chip--pill', shape === 'pill')
+    return this
+  }
+
+  setSize(size: 'md' | 'sm'): this {
+    this.el.toggleClass('pm-chip--sm', size === 'sm')
+    return this
+  }
+
+  setTooltip(text: string): this {
+    this.el.setAttribute('title', text)
+    return this
+  }
+
+  setRemovable(onRemove: () => void): this {
+    if (!this.rmBtn) {
+      this.rmBtn = this.el.createEl('button', { cls: 'pm-chip-rm' })
+      setIcon(this.rmBtn, 'x')
+    }
+    this.rmBtn.onclick = (e) => {
+      e.preventDefault()
+      e.stopPropagation()
+      onRemove()
+    }
+    return this
+  }
+}

--- a/src/ui/primitives/DueDateChip.ts
+++ b/src/ui/primitives/DueDateChip.ts
@@ -1,6 +1,5 @@
 export class DueDateChip {
   el: HTMLElement
-  private urgencyClass: string | null = null
 
   constructor(parentEl: HTMLElement) {
     this.el = parentEl.createEl('span', { cls: 'pm-due-chip' })
@@ -17,13 +16,8 @@ export class DueDateChip {
   }
 
   setUrgency(urgency: 'normal' | 'near' | 'overdue'): this {
-    if (this.urgencyClass) {
-      this.el.removeClass(this.urgencyClass)
-      this.urgencyClass = null
-    }
-    if (urgency === 'near') this.urgencyClass = 'pm-due-chip--near'
-    else if (urgency === 'overdue') this.urgencyClass = 'pm-due-chip--overdue'
-    if (this.urgencyClass) this.el.addClass(this.urgencyClass)
+    this.el.toggleClass('pm-due-chip--near', urgency === 'near')
+    this.el.toggleClass('pm-due-chip--overdue', urgency === 'overdue')
     return this
   }
 

--- a/src/ui/primitives/DueDateChip.ts
+++ b/src/ui/primitives/DueDateChip.ts
@@ -1,0 +1,40 @@
+export class DueDateChip {
+  el: HTMLElement
+  private urgencyClass: string | null = null
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createEl('span', { cls: 'pm-due-chip' })
+  }
+
+  setLabel(text: string): this {
+    this.el.setText(text)
+    return this
+  }
+
+  setVariant(variant: 'chip' | 'label'): this {
+    this.el.toggleClass('pm-due-chip--label', variant === 'label')
+    return this
+  }
+
+  setUrgency(urgency: 'normal' | 'near' | 'overdue'): this {
+    if (this.urgencyClass) {
+      this.el.removeClass(this.urgencyClass)
+      this.urgencyClass = null
+    }
+    if (urgency === 'near') this.urgencyClass = 'pm-due-chip--near'
+    else if (urgency === 'overdue') this.urgencyClass = 'pm-due-chip--overdue'
+    if (this.urgencyClass) this.el.addClass(this.urgencyClass)
+    return this
+  }
+
+  setPlaceholder(isPlaceholder: boolean): this {
+    this.el.toggleClass('pm-due-chip--placeholder', isPlaceholder)
+    return this
+  }
+
+  onClick(callback: (e: MouseEvent) => unknown): this {
+    this.el.addClass('pm-due-chip--interactive')
+    this.el.addEventListener('click', callback)
+    return this
+  }
+}

--- a/src/ui/primitives/DueDateChip.ts
+++ b/src/ui/primitives/DueDateChip.ts
@@ -26,9 +26,9 @@ export class DueDateChip {
     return this
   }
 
-  onClick(callback: (e: MouseEvent) => unknown): this {
+  onClick(handler: (e: MouseEvent) => unknown): this {
     this.el.addClass('pm-due-chip--interactive')
-    this.el.addEventListener('click', callback)
+    this.el.addEventListener('click', handler)
     return this
   }
 }

--- a/src/ui/primitives/Pill.ts
+++ b/src/ui/primitives/Pill.ts
@@ -1,0 +1,37 @@
+export class Pill {
+  buttonEl: HTMLButtonElement
+
+  constructor(parentEl: HTMLElement) {
+    this.buttonEl = parentEl.createEl('button', { cls: 'pm-pill' })
+  }
+
+  setLabel(text: string): this {
+    this.buttonEl.setText(text)
+    return this
+  }
+
+  setActive(active: boolean): this {
+    this.buttonEl.toggleClass('pm-pill--active', active)
+    return this
+  }
+
+  setShape(shape: 'rounded' | 'pill'): this {
+    this.buttonEl.toggleClass('pm-pill--pill', shape === 'pill')
+    return this
+  }
+
+  setAriaLabel(label: string): this {
+    this.buttonEl.setAttribute('aria-label', label)
+    return this
+  }
+
+  onClick(callback: (e: MouseEvent) => unknown): this {
+    this.buttonEl.addEventListener('click', callback)
+    return this
+  }
+
+  onContextMenu(callback: (e: MouseEvent) => unknown): this {
+    this.buttonEl.addEventListener('contextmenu', callback)
+    return this
+  }
+}

--- a/src/ui/primitives/Pill.ts
+++ b/src/ui/primitives/Pill.ts
@@ -25,13 +25,13 @@ export class Pill {
     return this
   }
 
-  onClick(callback: (e: MouseEvent) => unknown): this {
-    this.el.addEventListener('click', callback)
+  onClick(handler: (e: MouseEvent) => unknown): this {
+    this.el.addEventListener('click', handler)
     return this
   }
 
-  onContextMenu(callback: (e: MouseEvent) => unknown): this {
-    this.el.addEventListener('contextmenu', callback)
+  onContextMenu(handler: (e: MouseEvent) => unknown): this {
+    this.el.addEventListener('contextmenu', handler)
     return this
   }
 }

--- a/src/ui/primitives/Pill.ts
+++ b/src/ui/primitives/Pill.ts
@@ -1,37 +1,37 @@
 export class Pill {
-  buttonEl: HTMLButtonElement
+  el: HTMLButtonElement
 
   constructor(parentEl: HTMLElement) {
-    this.buttonEl = parentEl.createEl('button', { cls: 'pm-pill' })
+    this.el = parentEl.createEl('button', { cls: 'pm-pill' })
   }
 
   setLabel(text: string): this {
-    this.buttonEl.setText(text)
+    this.el.setText(text)
     return this
   }
 
   setActive(active: boolean): this {
-    this.buttonEl.toggleClass('pm-pill--active', active)
+    this.el.toggleClass('pm-pill--active', active)
     return this
   }
 
   setShape(shape: 'rounded' | 'pill'): this {
-    this.buttonEl.toggleClass('pm-pill--pill', shape === 'pill')
+    this.el.toggleClass('pm-pill--pill', shape === 'pill')
     return this
   }
 
   setAriaLabel(label: string): this {
-    this.buttonEl.setAttribute('aria-label', label)
+    this.el.setAttribute('aria-label', label)
     return this
   }
 
   onClick(callback: (e: MouseEvent) => unknown): this {
-    this.buttonEl.addEventListener('click', callback)
+    this.el.addEventListener('click', callback)
     return this
   }
 
   onContextMenu(callback: (e: MouseEvent) => unknown): this {
-    this.buttonEl.addEventListener('contextmenu', callback)
+    this.el.addEventListener('contextmenu', callback)
     return this
   }
 }

--- a/src/ui/primitives/ProgressBar.ts
+++ b/src/ui/primitives/ProgressBar.ts
@@ -1,0 +1,38 @@
+export class ProgressBar {
+  el: HTMLDivElement
+  private fill: HTMLDivElement
+  private labelEl: HTMLElement | null = null
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createDiv('pm-progress')
+    const track = this.el.createDiv('pm-progress-track')
+    this.fill = track.createDiv('pm-progress-fill')
+  }
+
+  setValue(percent: number): this {
+    const clamped = Math.max(0, Math.min(100, percent))
+    this.fill.style.width = `${clamped}%`
+    if (this.labelEl) this.labelEl.setText(`${Math.round(clamped)}%`)
+    return this
+  }
+
+  setColor(color: string): this {
+    this.el.style.setProperty('--pm-progress-color', color)
+    return this
+  }
+
+  setSize(size: 'sm' | 'md'): this {
+    this.el.toggleClass('pm-progress--sm', size === 'sm')
+    return this
+  }
+
+  setShowLabel(show: boolean): this {
+    if (show && !this.labelEl) {
+      this.labelEl = this.el.createEl('span', { cls: 'pm-progress-label', text: '0%' })
+    } else if (!show && this.labelEl) {
+      this.labelEl.remove()
+      this.labelEl = null
+    }
+    return this
+  }
+}

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -15,6 +15,7 @@ import { AvatarStack } from '../ui/primitives/AvatarStack'
 import { Badge } from '../ui/primitives/Badge'
 import { Chip } from '../ui/primitives/Chip'
 import { DueDateChip } from '../ui/primitives/DueDateChip'
+import { ProgressBar } from '../ui/primitives/ProgressBar'
 import { buildTaskContextMenu } from '../ui/TaskContextMenu'
 import type { SubView } from './SubView'
 
@@ -201,9 +202,7 @@ export class KanbanView implements SubView {
 
     // Progress mini bar
     if (task.progress > 0) {
-      const pbar = body.createDiv('pm-kanban-card-pbar')
-      const pfill = pbar.createDiv('pm-kanban-card-pbar-fill')
-      pfill.setCssStyles({ width: `${task.progress}%` })
+      new ProgressBar(body).setSize('sm').setValue(task.progress)
     }
 
     // Subtask count

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -14,6 +14,7 @@ import { openTaskModal } from '../ui/ModalFactory'
 import { AvatarStack } from '../ui/primitives/AvatarStack'
 import { Badge } from '../ui/primitives/Badge'
 import { Chip } from '../ui/primitives/Chip'
+import { DueDateChip } from '../ui/primitives/DueDateChip'
 import { buildTaskContextMenu } from '../ui/TaskContextMenu'
 import type { SubView } from './SubView'
 
@@ -192,11 +193,10 @@ export class KanbanView implements SubView {
 
     if (task.due) {
       const overdue = isTaskOverdue(task, this.plugin.settings.statuses)
-      const chip = footer.createEl('span', {
-        text: formatDateShort(task.due),
-        cls: 'pm-kanban-due'
-      })
-      if (overdue) chip.addClass('pm-kanban-due--overdue')
+      new DueDateChip(footer)
+        .setVariant('label')
+        .setLabel(formatDateShort(task.due))
+        .setUrgency(overdue ? 'overdue' : 'normal')
     }
 
     // Progress mini bar

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -13,6 +13,7 @@ import {
 import { openTaskModal } from '../ui/ModalFactory'
 import { AvatarStack } from '../ui/primitives/AvatarStack'
 import { Badge } from '../ui/primitives/Badge'
+import { Chip } from '../ui/primitives/Chip'
 import { buildTaskContextMenu } from '../ui/TaskContextMenu'
 import type { SubView } from './SubView'
 
@@ -180,7 +181,7 @@ export class KanbanView implements SubView {
     if (task.tags.length) {
       const tagsEl = body.createDiv('pm-kanban-card-tags')
       for (const tag of task.tags.slice(0, 3)) {
-        tagsEl.createEl('span', { text: tag, cls: 'pm-tag pm-tag--sm' })
+        new Chip(tagsEl).setLabel(tag).setShape('pill').setSize('sm')
       }
     }
 

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -12,6 +12,7 @@ import {
   safeAsync
 } from '../utils'
 import { openTaskModal } from '../ui/ModalFactory'
+import { Badge } from '../ui/primitives/Badge'
 import { buildTaskContextMenu } from '../ui/TaskContextMenu'
 import type { SubView } from './SubView'
 
@@ -157,25 +158,13 @@ export class KanbanView implements SubView {
     const titleRow = body.createDiv('pm-kanban-card-title-row')
     titleRow.createEl('span', { text: task.title, cls: 'pm-kanban-card-title' })
     if (task.type === 'milestone') {
-      titleRow.createEl('span', {
-        text: 'M',
-        cls: 'pm-task-badge pm-task-badge--milestone',
-        attr: { title: 'Milestone' }
-      })
+      new Badge(titleRow).setLabel('M').setSize('sm').setColor('var(--color-purple)').setTooltip('Milestone')
     }
     if (task.type === 'subtask') {
-      titleRow.createEl('span', {
-        text: 'Sub',
-        cls: 'pm-task-badge pm-task-badge--subtask',
-        attr: { title: 'Subtask' }
-      })
+      new Badge(titleRow).setLabel('Sub').setSize('sm').setColor('var(--color-green)').setTooltip('Subtask')
     }
     if (task.recurrence) {
-      titleRow.createEl('span', {
-        text: 'R',
-        cls: 'pm-task-badge pm-task-badge--recurrence',
-        attr: { title: 'Recurring' }
-      })
+      new Badge(titleRow).setLabel('R').setSize('sm').setColor('var(--color-blue)').setTooltip('Recurring')
     }
 
     // Time badge

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -1,27 +1,15 @@
 import { Menu } from 'obsidian'
 import type PMPlugin from '../main'
 import { Project, Task, TaskStatus } from '../types'
-import { totalLoggedHours, flattenTasks } from '../store/TaskTreeOps'
-import {
-  formatDateShort,
-  isTaskOverdue,
-  isTerminalStatus,
-  getPriorityConfig,
-  formatBadgeText,
-  safeAsync
-} from '../utils'
+import { flattenTasks, totalLoggedHours } from '../store/TaskTreeOps'
+import { isTaskOverdue, isTerminalStatus, getPriorityConfig } from '../utils'
 import { openTaskModal } from '../ui/ModalFactory'
-import { AvatarStack } from '../ui/primitives/AvatarStack'
-import { Badge } from '../ui/primitives/Badge'
-import { Chip } from '../ui/primitives/Chip'
-import { DueDateChip } from '../ui/primitives/DueDateChip'
-import { ProgressBar } from '../ui/primitives/ProgressBar'
 import { buildTaskContextMenu } from '../ui/TaskContextMenu'
+import { KanbanColumn, type KanbanCardData } from '../ui/composites/KanbanColumn'
 import type { SubView } from './SubView'
 
 export class KanbanView implements SubView {
   private dragTask: Task | null = null
-  private cleanupFns: (() => void)[] = []
 
   constructor(
     private container: HTMLElement,
@@ -30,13 +18,7 @@ export class KanbanView implements SubView {
     private onRefresh: () => Promise<void>
   ) {}
 
-  destroy(): void {
-    for (const fn of this.cleanupFns) fn()
-    this.cleanupFns = []
-  }
-
   render(): void {
-    this.destroy()
     this.container.empty()
     this.container.addClass('pm-kanban-view')
 
@@ -44,7 +26,20 @@ export class KanbanView implements SubView {
 
     for (const status of this.plugin.settings.statuses) {
       const tasks = this.getTasksForStatus(status.id)
-      this.renderColumn(board, status, tasks)
+      const cards = tasks.map((task) => this.buildCardData(task))
+      new KanbanColumn(board, {
+        status,
+        cards,
+        onCardClick: (task) => this.openTask(task),
+        onCardContextMenu: (task, e) => this.openContextMenu(task, e),
+        onCardDragStart: (task) => {
+          this.dragTask = task
+        },
+        onCardDragEnd: () => {
+          this.dragTask = null
+        },
+        onDrop: (taskId, newStatus) => this.handleDrop(taskId, newStatus)
+      })
     }
   }
 
@@ -57,75 +52,31 @@ export class KanbanView implements SubView {
     return this.project.tasks.filter((t) => t.status === status && !t.archived)
   }
 
-  private renderColumn(
-    board: HTMLElement,
-    status: { id: string; label: string; color: string; icon: string },
-    tasks: Task[]
-  ): void {
-    const col = board.createDiv('pm-kanban-col')
-    col.dataset.status = status.id
+  private buildCardData(task: Task): KanbanCardData {
+    const priorityConfig = getPriorityConfig(this.plugin.settings.priorities, task.priority)
+    const priorityColor =
+      priorityConfig && task.priority !== 'medium' && task.priority !== 'low' ? priorityConfig.color : undefined
 
-    // Column header
-    const header = col.createDiv('pm-kanban-col-header')
-    header.style.setProperty('--col-color', status.color)
-
-    const topBar = header.createDiv('pm-kanban-col-topbar')
-    topBar.setCssStyles({ background: status.color })
-
-    const titleRow = header.createDiv('pm-kanban-col-title-row')
-    const badge = titleRow.createEl('span', {
-      text: formatBadgeText(status.icon, status.label),
-      cls: 'pm-kanban-col-badge'
-    })
-    badge.style.color = status.color
-
-    const headerRight = titleRow.createDiv('pm-kanban-col-header-right')
-    headerRight.createEl('span', {
-      text: String(tasks.length),
-      cls: 'pm-kanban-col-count'
-    })
-
-    // Cards container
-    const cardsEl = col.createDiv('pm-kanban-cards')
-    cardsEl.dataset.status = status.id
-
-    for (const task of tasks) {
-      this.renderCard(cardsEl, task, status.color)
+    let parentTitle: string | undefined
+    if (this.plugin.settings.kanbanShowSubtasks && task.type === 'subtask') {
+      const parent = this.findParentTask(task.id)
+      if (parent) parentTitle = parent.title
     }
 
-    // Drop zone events
-    cardsEl.addEventListener('dragover', (e) => {
-      e.preventDefault()
-      cardsEl.addClass('pm-kanban-drop-target')
-      const afterEl = this.getDragAfterElement(cardsEl, e.clientY)
-      const dragging = cardsEl.querySelector('.pm-kanban-card--dragging')
-      if (dragging) {
-        if (afterEl) {
-          cardsEl.insertBefore(dragging, afterEl)
-        } else {
-          cardsEl.appendChild(dragging)
-        }
-      }
-    })
+    let subtaskProgress: { done: number; total: number } | undefined
+    if (task.subtasks.length) {
+      const done = task.subtasks.filter((s) => isTerminalStatus(s.status, this.plugin.settings.statuses)).length
+      subtaskProgress = { done, total: task.subtasks.length }
+    }
 
-    cardsEl.addEventListener('dragleave', () => {
-      cardsEl.removeClass('pm-kanban-drop-target')
-    })
-
-    cardsEl.addEventListener(
-      'drop',
-      safeAsync(async (e: DragEvent) => {
-        e.preventDefault()
-        cardsEl.removeClass('pm-kanban-drop-target')
-        if (!this.dragTask) return
-        const newStatus = status.id
-        if (newStatus !== this.dragTask.status) {
-          await this.plugin.store.updateTask(this.project, this.dragTask.id, { status: newStatus })
-          await this.onRefresh()
-        }
-        this.dragTask = null
-      })
-    )
+    return {
+      task,
+      priorityColor,
+      parentTitle,
+      subtaskProgress,
+      loggedHours: totalLoggedHours(task),
+      overdue: isTaskOverdue(task, this.plugin.settings.statuses)
+    }
   }
 
   private findParentTask(taskId: string): Task | null {
@@ -136,126 +87,25 @@ export class KanbanView implements SubView {
     return null
   }
 
-  private renderCard(container: HTMLElement, task: Task, columnColor: string): void {
-    const card = container.createDiv('pm-kanban-card')
-    card.draggable = true
-    card.dataset.taskId = task.id
-
-    const priorityConfig = getPriorityConfig(this.plugin.settings.priorities, task.priority)
-    if (priorityConfig && task.priority !== 'medium' && task.priority !== 'low') {
-      const priorityBar = card.createDiv('pm-kanban-card-priority-bar')
-      priorityBar.setCssStyles({ background: priorityConfig.color })
-    }
-
-    const body = card.createDiv('pm-kanban-card-body')
-
-    // Parent label for subtasks shown in flat mode
-    if (this.plugin.settings.kanbanShowSubtasks && task.type === 'subtask') {
-      const parent = this.findParentTask(task.id)
-      if (parent) {
-        body.createEl('span', { text: parent.title, cls: 'pm-kanban-card-parent' })
+  private openTask(task: Task): void {
+    openTaskModal(this.plugin, this.project, {
+      task,
+      onSave: async () => {
+        await this.onRefresh()
       }
-    }
-
-    // Title + type badges
-    const titleRow = body.createDiv('pm-kanban-card-title-row')
-    titleRow.createEl('span', { text: task.title, cls: 'pm-kanban-card-title' })
-    if (task.type === 'milestone') {
-      new Badge(titleRow).setLabel('M').setSize('sm').setColor('var(--color-purple)').setTooltip('Milestone')
-    }
-    if (task.type === 'subtask') {
-      new Badge(titleRow).setLabel('Sub').setSize('sm').setColor('var(--color-green)').setTooltip('Subtask')
-    }
-    if (task.recurrence) {
-      new Badge(titleRow).setLabel('R').setSize('sm').setColor('var(--color-blue)').setTooltip('Recurring')
-    }
-
-    // Time badge
-    const logged = totalLoggedHours(task)
-    const est = task.timeEstimate ?? 0
-    if (logged > 0 || est > 0) {
-      const timeBadge = body.createEl('span', { cls: 'pm-time-chip pm-time-chip--sm' })
-      timeBadge.setText(est > 0 ? `${logged}/${est}h` : `${logged}h`)
-      if (est > 0 && logged > est) timeBadge.addClass('pm-time-chip--over')
-    }
-
-    // Tags
-    if (task.tags.length) {
-      const tagsEl = body.createDiv('pm-kanban-card-tags')
-      for (const tag of task.tags.slice(0, 3)) {
-        new Chip(tagsEl).setLabel(tag).setShape('pill').setSize('sm')
-      }
-    }
-
-    // Footer: assignees + due date
-    const footer = body.createDiv('pm-kanban-card-footer')
-
-    new AvatarStack(footer).setNames(task.assignees).setMax(3).setSize('sm')
-
-    if (task.due) {
-      const overdue = isTaskOverdue(task, this.plugin.settings.statuses)
-      new DueDateChip(footer)
-        .setVariant('label')
-        .setLabel(formatDateShort(task.due))
-        .setUrgency(overdue ? 'overdue' : 'normal')
-    }
-
-    // Progress mini bar
-    if (task.progress > 0) {
-      new ProgressBar(body).setSize('sm').setValue(task.progress)
-    }
-
-    // Subtask count
-    if (task.subtasks.length) {
-      body.createEl('span', {
-        text: `${task.subtasks.filter((s) => isTerminalStatus(s.status, this.plugin.settings.statuses)).length}/${task.subtasks.length} subtasks`,
-        cls: 'pm-kanban-card-subtasks'
-      })
-    }
-
-    // Drag events
-    card.addEventListener('dragstart', () => {
-      this.dragTask = task
-      card.addClass('pm-kanban-card--dragging')
-      activeWindow.setTimeout(() => card.addClass('pm-dragging'), 0)
-    })
-
-    card.addEventListener('dragend', () => {
-      card.removeClass('pm-kanban-card--dragging')
-      card.removeClass('pm-dragging')
-    })
-
-    // Click to open
-    card.addEventListener('click', () => {
-      openTaskModal(this.plugin, this.project, {
-        task,
-        onSave: async () => {
-          await this.onRefresh()
-        }
-      })
-    })
-
-    // Right-click context menu
-    card.addEventListener('contextmenu', (e) => {
-      e.preventDefault()
-      const menu = new Menu()
-      buildTaskContextMenu(menu, task, { plugin: this.plugin, project: this.project, onRefresh: this.onRefresh })
-      menu.showAtMouseEvent(e)
     })
   }
 
-  private getDragAfterElement(container: HTMLElement, y: number): Element | null {
-    const cards = Array.from(container.querySelectorAll('.pm-kanban-card:not(.pm-kanban-card--dragging)'))
-    let closest: Element | null = null
-    let closestOffset = Number.NEGATIVE_INFINITY
-    for (const card of cards) {
-      const box = card.getBoundingClientRect()
-      const offset = y - box.top - box.height / 2
-      if (offset < 0 && offset > closestOffset) {
-        closestOffset = offset
-        closest = card
-      }
-    }
-    return closest
+  private openContextMenu(task: Task, e: MouseEvent): void {
+    const menu = new Menu()
+    buildTaskContextMenu(menu, task, { plugin: this.plugin, project: this.project, onRefresh: this.onRefresh })
+    menu.showAtMouseEvent(e)
+  }
+
+  private async handleDrop(taskId: string, newStatus: TaskStatus): Promise<void> {
+    if (!this.dragTask || this.dragTask.id !== taskId) return
+    if (newStatus === this.dragTask.status) return
+    await this.plugin.store.updateTask(this.project, this.dragTask.id, { status: newStatus })
+    await this.onRefresh()
   }
 }

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -3,7 +3,6 @@ import type PMPlugin from '../main'
 import { Project, Task, TaskStatus } from '../types'
 import { totalLoggedHours, flattenTasks } from '../store/TaskTreeOps'
 import {
-  stringToColor,
   formatDateShort,
   isTaskOverdue,
   isTerminalStatus,
@@ -12,6 +11,7 @@ import {
   safeAsync
 } from '../utils'
 import { openTaskModal } from '../ui/ModalFactory'
+import { AvatarStack } from '../ui/primitives/AvatarStack'
 import { Badge } from '../ui/primitives/Badge'
 import { buildTaskContextMenu } from '../ui/TaskContextMenu'
 import type { SubView } from './SubView'
@@ -187,13 +187,7 @@ export class KanbanView implements SubView {
     // Footer: assignees + due date
     const footer = body.createDiv('pm-kanban-card-footer')
 
-    const avatars = footer.createDiv('pm-kanban-card-avatars')
-    for (const a of task.assignees.slice(0, 3)) {
-      const av = avatars.createEl('span', { cls: 'pm-avatar pm-avatar--sm' })
-      av.textContent = a.slice(0, 2).toUpperCase()
-      av.title = a
-      av.style.background = stringToColor(a)
-    }
+    new AvatarStack(footer).setNames(task.assignees).setMax(3).setSize('sm')
 
     if (task.due) {
       const overdue = isTaskOverdue(task, this.plugin.settings.statuses)

--- a/src/views/ProjectListRenderer.ts
+++ b/src/views/ProjectListRenderer.ts
@@ -3,6 +3,7 @@ import type PMPlugin from '../main'
 import type { Task, StatusConfig } from '../types'
 import { safeAsync, isTerminalStatus } from '../utils'
 import { openProjectModal } from '../ui/ModalFactory'
+import { ProgressBar } from '../ui/primitives/ProgressBar'
 
 export interface ProjectListContext {
   plugin: PMPlugin
@@ -71,10 +72,10 @@ export async function renderProjectListContent(ctx: ProjectListContext): Promise
     const done = countTasks(project.tasks, true, ctx.plugin.settings.statuses)
     meta.createEl('span', { text: `${done}/${total} tasks`, cls: 'pm-project-card-tasks' })
 
-    const progressBar = body.createDiv('pm-project-card-progress')
-    const fill = progressBar.createDiv('pm-project-card-progress-fill')
-    fill.style.width = total ? `${Math.round((done / total) * 100)}%` : '0%'
-    fill.style.background = project.color
+    new ProgressBar(body)
+      .setSize('sm')
+      .setValue(total ? (done / total) * 100 : 0)
+      .setColor(project.color)
 
     card.addEventListener(
       'click',

--- a/src/views/ProjectListRenderer.ts
+++ b/src/views/ProjectListRenderer.ts
@@ -1,4 +1,4 @@
-import { TFile, Menu } from 'obsidian'
+import { ButtonComponent, TFile, Menu } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Task, StatusConfig } from '../types'
 import { safeAsync, isTerminalStatus } from '../utils'
@@ -16,15 +16,17 @@ export function renderProjectListToolbar(ctx: ProjectListContext): void {
   ctx.toolbarEl.empty()
   ctx.toolbarEl.createEl('h2', { text: 'Project manager', cls: 'pm-toolbar-title' })
 
-  const newBtn = ctx.toolbarEl.createEl('button', { text: '+ new project', cls: 'pm-btn pm-btn-primary' })
-  newBtn.addEventListener('click', () => {
-    openProjectModal(ctx.plugin, {
-      onSave: async (project) => {
-        const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
-        if (file instanceof TFile) await ctx.openProjectFile(file)
-      }
+  new ButtonComponent(ctx.toolbarEl)
+    .setButtonText('+ new project')
+    .setCta()
+    .onClick(() => {
+      openProjectModal(ctx.plugin, {
+        onSave: async (project) => {
+          const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
+          if (file instanceof TFile) await ctx.openProjectFile(file)
+        }
+      })
     })
-  })
 }
 
 export async function renderProjectListContent(ctx: ProjectListContext): Promise<void> {
@@ -38,15 +40,17 @@ export async function renderProjectListContent(ctx: ProjectListContext): Promise
     empty.createEl('div', { text: '\ud83d\udccb', cls: 'pm-empty-icon' })
     empty.createEl('h3', { text: 'No projects yet' })
     empty.createEl('p', { text: 'Create your first project to get started.' })
-    const btn = empty.createEl('button', { text: '+ new project', cls: 'pm-btn pm-btn-primary' })
-    btn.addEventListener('click', () => {
-      openProjectModal(ctx.plugin, {
-        onSave: async (project) => {
-          const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
-          if (file instanceof TFile) await ctx.openProjectFile(file)
-        }
+    new ButtonComponent(empty)
+      .setButtonText('+ new project')
+      .setCta()
+      .onClick(() => {
+        openProjectModal(ctx.plugin, {
+          onSave: async (project) => {
+            const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
+            if (file instanceof TFile) await ctx.openProjectFile(file)
+          }
+        })
       })
-    })
     return
   }
 

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf, TFile, EventRef } from 'obsidian'
+import { ButtonComponent, ExtraButtonComponent, ItemView, WorkspaceLeaf, TFile, EventRef } from 'obsidian'
 import type PMPlugin from '../main'
 import { Project, ViewMode } from '../types'
 import { truncateTitle, safeAsync } from '../utils'
@@ -199,19 +199,20 @@ export class ProjectView extends ItemView {
     }
 
     const right = this.toolbarEl.createDiv('pm-toolbar-right')
-    const addBtn = right.createEl('button', { text: '+ add task', cls: 'pm-btn pm-btn-primary' })
-    addBtn.addEventListener('click', () => {
-      if (!this.project) return
-      openTaskModal(this.plugin, this.project, {
-        onSave: async () => {
-          await this.refreshProject()
-        }
+    new ButtonComponent(right)
+      .setButtonText('+ add task')
+      .setCta()
+      .onClick(() => {
+        if (!this.project) return
+        openTaskModal(this.plugin, this.project, {
+          onSave: async () => {
+            await this.refreshProject()
+          }
+        })
       })
-    })
 
     if (this.currentView === 'gantt') {
-      const milestoneBtn = right.createEl('button', { text: '+ milestone', cls: 'pm-btn pm-btn-ghost' })
-      milestoneBtn.addEventListener('click', () => {
+      new ButtonComponent(right).setButtonText('+ milestone').onClick(() => {
         if (!this.project) return
         openTaskModal(this.plugin, this.project, {
           defaults: { type: 'milestone' },
@@ -222,21 +223,19 @@ export class ProjectView extends ItemView {
       })
     }
 
-    const settingsBtn = right.createEl('button', {
-      cls: 'pm-btn pm-btn-icon',
-      attr: { 'aria-label': 'Project settings' }
-    })
-    settingsBtn.createEl('span', { text: '⚙' })
-    settingsBtn.addEventListener('click', () => {
-      openProjectModal(this.plugin, {
-        project: this.project,
-        onSave: (updated) => {
-          this.project = updated
-          this.renderProjectToolbar()
-          this.renderCurrentView()
-        }
+    new ExtraButtonComponent(right)
+      .setIcon('settings')
+      .setTooltip('Project settings')
+      .onClick(() => {
+        openProjectModal(this.plugin, {
+          project: this.project,
+          onSave: (updated) => {
+            this.project = updated
+            this.renderProjectToolbar()
+            this.renderCurrentView()
+          }
+        })
       })
-    })
   }
 
   private renderCurrentView(): void {

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -1,3 +1,4 @@
+import { ButtonComponent } from 'obsidian'
 import type PMPlugin from '../../main'
 import type { Project, Task, GanttGranularity } from '../../types'
 import { type FlatTask, flattenTasks, filterArchived, filterDone } from '../../store/TaskTreeOps'
@@ -97,22 +98,14 @@ export class GanttView implements SubView {
     }
 
     bar.createEl('span', { cls: 'pm-gantt-sep' })
-    const todayBtn = bar.createEl('button', { text: 'Today', cls: 'pm-btn pm-btn-ghost pm-gantt-today-btn' })
-    todayBtn.addEventListener('click', () => this.scrollToToday())
+    new ButtonComponent(bar).setButtonText('Today').onClick(() => this.scrollToToday())
 
-    const expBtn = bar.createEl('button', { text: 'Expand all', cls: 'pm-btn pm-btn-ghost' })
-    expBtn.addEventListener('click', () => this.setAllCollapsed(false))
-    const colBtn = bar.createEl('button', { text: 'Collapse all', cls: 'pm-btn pm-btn-ghost' })
-    colBtn.addEventListener('click', () => this.setAllCollapsed(true))
+    new ButtonComponent(bar).setButtonText('Expand all').onClick(() => this.setAllCollapsed(false))
+    new ButtonComponent(bar).setButtonText('Collapse all').onClick(() => this.setAllCollapsed(true))
 
     bar.createEl('span', { cls: 'pm-gantt-sep' })
     const hideDone = this.plugin.settings.ganttHideDone
-    const toggleBtn = bar.createEl('button', {
-      text: hideDone ? 'Show completed' : 'Hide completed',
-      cls: 'pm-btn pm-btn-ghost'
-    })
-    if (hideDone) toggleBtn.addClass('pm-gantt-toggle-active')
-    toggleBtn.addEventListener('click', () => {
+    new ButtonComponent(bar).setButtonText(hideDone ? 'Show completed' : 'Hide completed').onClick(() => {
       this.plugin.settings.ganttHideDone = !this.plugin.settings.ganttHideDone
       void this.plugin.saveSettings()
       this.render()

--- a/src/views/table/BulkActionBar.ts
+++ b/src/views/table/BulkActionBar.ts
@@ -1,4 +1,4 @@
-import { Menu } from 'obsidian'
+import { ButtonComponent, ExtraButtonComponent, Menu } from 'obsidian'
 import type { Task, TaskStatus, TaskPriority } from '../../types'
 import { findTask, flattenTasks, collectAllAssignees, collectAllTags } from '../../store'
 import { formatBadgeText } from '../../utils'
@@ -67,8 +67,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   left.createEl('span', { text: `${count} selected`, cls: 'pm-bulk-bar-count' })
 
   // Status button
-  const statusBtn = left.createEl('button', { text: 'Set status', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  statusBtn.addEventListener('click', (e) => {
+  new ButtonComponent(left).setButtonText('Set status').onClick((e) => {
     const menu = new Menu()
     for (const s of ctx.plugin.settings.statuses) {
       menu.addItem((item) =>
@@ -79,8 +78,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   })
 
   // Priority button
-  const priorityBtn = left.createEl('button', { text: 'Set priority', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  priorityBtn.addEventListener('click', (e) => {
+  new ButtonComponent(left).setButtonText('Set priority').onClick((e) => {
     const menu = new Menu()
     for (const p of ctx.plugin.settings.priorities) {
       menu.addItem((item) =>
@@ -93,8 +91,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   })
 
   // Assignee button
-  const assigneeBtn = left.createEl('button', { text: 'Set assignee', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  assigneeBtn.addEventListener('click', (e) => {
+  new ButtonComponent(left).setButtonText('Set assignee').onClick((e) => {
     const menu = new Menu()
     const allMembers = collectAllAssignees(ctx.project.tasks, [
       ...ctx.project.teamMembers,
@@ -118,8 +115,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   })
 
   // Tag button
-  const tagBtn = left.createEl('button', { text: 'Set tag', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  tagBtn.addEventListener('click', (e) => {
+  new ButtonComponent(left).setButtonText('Set tag').onClick((e) => {
     const menu = new Menu()
     const allTags = collectAllTags(ctx.project.tasks)
     for (const t of allTags) {
@@ -138,8 +134,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   })
 
   // Due Date button
-  const dueBtn = left.createEl('button', { text: 'Set due date', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  dueBtn.addEventListener('click', (e) => {
+  new ButtonComponent(left).setButtonText('Set due date').onClick((e) => {
     const menu = new Menu()
     const now = today()
     const ahead = (days: number) => now.add({ days }).toString()
@@ -176,8 +171,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   })
 
   // Progress button
-  const progressBtn = left.createEl('button', { text: 'Set progress', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  progressBtn.addEventListener('click', (e) => {
+  new ButtonComponent(left).setButtonText('Set progress').onClick((e) => {
     const menu = new Menu()
     for (const pct of [0, 25, 50, 75, 100]) {
       menu.addItem((item) => item.setTitle(`${pct}%`).onClick(() => onAction({ type: 'set-progress', progress: pct })))
@@ -186,8 +180,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   })
 
   // Set parent / Remove parent buttons
-  const parentBtn = left.createEl('button', { text: 'Set parent', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  parentBtn.addEventListener('click', () => {
+  new ButtonComponent(left).setButtonText('Set parent').onClick(() => {
     const selectedIdSet = new Set(ctx.state.selectedTaskIds)
     // Collect all descendants of selected tasks to prevent circular refs
     const excludedIds = new Set<string>(selectedIdSet)
@@ -208,8 +201,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
     modal.open()
   })
 
-  const removeParentBtn = left.createEl('button', { text: 'Remove parent', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-  removeParentBtn.addEventListener('click', () => onAction({ type: 'remove-parent' }))
+  new ButtonComponent(left).setButtonText('Remove parent').onClick(() => onAction({ type: 'remove-parent' }))
 
   // Archive / Unarchive button — show based on selected tasks' state
   const selectedIds = [...ctx.state.selectedTaskIds]
@@ -218,37 +210,32 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   const hasNonArchived = selectedTasks.some((t) => !t.archived)
 
   if (hasNonArchived) {
-    const archiveBtn = left.createEl('button', { text: 'Archive', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-    archiveBtn.addEventListener('click', () => onAction({ type: 'archive' }))
+    new ButtonComponent(left).setButtonText('Archive').onClick(() => onAction({ type: 'archive' }))
   }
   if (hasArchived) {
-    const unarchiveBtn = left.createEl('button', { text: 'Unarchive', cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-    unarchiveBtn.addEventListener('click', () => onAction({ type: 'unarchive' }))
+    new ButtonComponent(left).setButtonText('Unarchive').onClick(() => onAction({ type: 'unarchive' }))
   }
 
   // Delete button
-  const deleteBtn = left.createEl('button', { text: 'Delete', cls: 'pm-btn pm-btn-danger pm-btn-sm' })
-  deleteBtn.addEventListener('click', () => {
-    onAction({ type: 'delete' })
-  })
+  new ButtonComponent(left)
+    .setButtonText('Delete')
+    .setWarning()
+    .onClick(() => onAction({ type: 'delete' }))
 
   // Right section: clear selection
   const right = bar.createDiv('pm-bulk-bar-right')
-  const clearBtn = right.createEl('button', {
-    cls: 'pm-btn pm-btn-ghost pm-btn-icon pm-btn-sm',
-    attr: { 'aria-label': 'Clear selection' }
-  })
-  clearBtn.setText('\u00d7')
-  clearBtn.addEventListener('click', () => {
-    ctx.state.selectedTaskIds.clear()
-    // Update row checkboxes
-    if (ctx.state.tableBody) {
-      const cbs = ctx.state.tableBody.querySelectorAll('.pm-select-checkbox')
-      cbs.forEach((cb) => {
-        ;(cb as HTMLInputElement).checked = false
-      })
-    }
-    updateSelectAllCheckbox(ctx.state)
-    renderBulkActionBar({ ctx, onAction })
-  })
+  new ExtraButtonComponent(right)
+    .setIcon('x')
+    .setTooltip('Clear selection')
+    .onClick(() => {
+      ctx.state.selectedTaskIds.clear()
+      if (ctx.state.tableBody) {
+        const cbs = ctx.state.tableBody.querySelectorAll('.pm-select-checkbox')
+        cbs.forEach((cb) => {
+          ;(cb as HTMLInputElement).checked = false
+        })
+      }
+      updateSelectAllCheckbox(ctx.state)
+      renderBulkActionBar({ ctx, onAction })
+    })
 }

--- a/src/views/table/FilterBar.ts
+++ b/src/views/table/FilterBar.ts
@@ -1,4 +1,4 @@
-import { Menu } from 'obsidian'
+import { ButtonComponent, Menu } from 'obsidian'
 import type PMPlugin from '../../main'
 import type { Project, FilterState, TaskPriority, DueDateFilter } from '../../types'
 import { makeDefaultFilter } from '../../types'
@@ -105,8 +105,7 @@ export function renderFilterBar(container: HTMLElement, ctx: FilterBarContext): 
   // Clear button
   const activeCount = countActiveFilters(ctx.filter)
   if (activeCount > 0) {
-    const clearBtn = bar.createEl('button', { text: `✕ Clear (${activeCount})`, cls: 'pm-btn pm-btn-ghost pm-btn-sm' })
-    clearBtn.addEventListener('click', () => {
+    new ButtonComponent(bar).setButtonText(`✕ Clear (${activeCount})`).onClick(() => {
       ctx.setFilter(makeDefaultFilter())
       ctx.setActiveSavedViewId(null)
       ctx.rerender()

--- a/src/views/table/FilterBar.ts
+++ b/src/views/table/FilterBar.ts
@@ -4,6 +4,7 @@ import type { Project, FilterState, TaskPriority, DueDateFilter } from '../../ty
 import { makeDefaultFilter } from '../../types'
 import { collectAllAssignees, collectAllTags } from '../../store'
 import { renderFilterDropdown } from '../../ui/FilterDropdown'
+import { Pill } from '../../ui/primitives/Pill'
 import { formatBadgeText } from '../../utils'
 
 export interface FilterBarContext {
@@ -90,17 +91,14 @@ export function renderFilterBar(container: HTMLElement, ctx: FilterBarContext): 
   renderDueDateFilter(bar, ctx)
 
   // Show archived toggle
-  const archiveBtn = bar.createEl('button', {
-    text: ctx.filter.showArchived ? 'Archived ✓' : 'Archived',
-    cls: 'pm-filter-dropdown-btn'
-  })
-  if (ctx.filter.showArchived) archiveBtn.addClass('pm-filter-dropdown-btn--active')
-  archiveBtn.addEventListener('click', () => {
-    ctx.filter.showArchived = !ctx.filter.showArchived
-    archiveBtn.setText(ctx.filter.showArchived ? 'Archived ✓' : 'Archived')
-    archiveBtn.toggleClass('pm-filter-dropdown-btn--active', ctx.filter.showArchived)
-    ctx.refreshTable()
-  })
+  const archivePill = new Pill(bar)
+    .setLabel(ctx.filter.showArchived ? 'Archived ✓' : 'Archived')
+    .setActive(ctx.filter.showArchived)
+    .onClick(() => {
+      ctx.filter.showArchived = !ctx.filter.showArchived
+      archivePill.setLabel(ctx.filter.showArchived ? 'Archived ✓' : 'Archived').setActive(ctx.filter.showArchived)
+      ctx.refreshTable()
+    })
 
   // Clear button
   const activeCount = countActiveFilters(ctx.filter)
@@ -122,28 +120,25 @@ function renderDueDateFilter(parent: HTMLElement, ctx: FilterBarContext): void {
     'this-month': 'This month',
     'no-date': 'No date'
   }
-  const btn = parent.createEl('button', {
-    text: current !== 'any' ? `Due: ${labels[current]}` : 'Due date',
-    cls: 'pm-filter-dropdown-btn'
-  })
-  if (current !== 'any') btn.addClass('pm-filter-dropdown-btn--active')
-
-  btn.addEventListener('click', (e) => {
-    const menu = new Menu()
-    const opts: DueDateFilter[] = ['any', 'overdue', 'this-week', 'this-month', 'no-date']
-    for (const opt of opts) {
-      menu.addItem((item) =>
-        item
-          .setTitle(labels[opt])
-          .setChecked(current === opt)
-          .onClick(() => {
-            ctx.filter.dueDateFilter = opt
-            ctx.rerender()
-          })
-      )
-    }
-    menu.showAtMouseEvent(e)
-  })
+  new Pill(parent)
+    .setLabel(current !== 'any' ? `Due: ${labels[current]}` : 'Due date')
+    .setActive(current !== 'any')
+    .onClick((e) => {
+      const menu = new Menu()
+      const opts: DueDateFilter[] = ['any', 'overdue', 'this-week', 'this-month', 'no-date']
+      for (const opt of opts) {
+        menu.addItem((item) =>
+          item
+            .setTitle(labels[opt])
+            .setChecked(current === opt)
+            .onClick(() => {
+              ctx.filter.dueDateFilter = opt
+              ctx.rerender()
+            })
+        )
+      }
+      menu.showAtMouseEvent(e)
+    })
 }
 
 function countActiveFilters(f: FilterState): number {

--- a/src/views/table/SavedViewsBar.ts
+++ b/src/views/table/SavedViewsBar.ts
@@ -1,7 +1,8 @@
-import { Menu } from 'obsidian'
+import { ButtonComponent, Menu } from 'obsidian'
 import type PMPlugin from '../../main'
 import type { Project, FilterState, SavedView } from '../../types'
 import { makeId, makeDefaultFilter } from '../../types'
+import { Pill } from '../../ui/primitives/Pill'
 import { safeAsync } from '../../utils'
 
 export interface SavedViewsContext {
@@ -35,64 +36,67 @@ export function renderSavedViewsBar(container: HTMLElement, ctx: SavedViewsConte
   const bar = container.createDiv('pm-saved-views-bar')
 
   // "All" pill
-  const allPill = bar.createEl('button', { text: 'All', cls: 'pm-saved-view-pill' })
-  if (!ctx.activeSavedViewId) allPill.addClass('pm-saved-view-pill--active')
-  allPill.addEventListener('click', () => {
-    ctx.setActiveSavedViewId(null)
-    ctx.setFilter(makeDefaultFilter())
-    ctx.setSort('status', 'asc')
-    ctx.rerender()
-  })
-
-  for (const sv of ctx.project.savedViews) {
-    const pill = bar.createEl('button', { text: sv.name, cls: 'pm-saved-view-pill' })
-    if (ctx.activeSavedViewId === sv.id) pill.addClass('pm-saved-view-pill--active')
-    pill.addEventListener('click', () => {
-      ctx.setActiveSavedViewId(sv.id)
-      ctx.setFilter({ ...sv.filter })
-      ctx.setSort(sv.sortKey, sv.sortDir)
+  new Pill(bar)
+    .setLabel('All')
+    .setShape('pill')
+    .setActive(!ctx.activeSavedViewId)
+    .onClick(() => {
+      ctx.setActiveSavedViewId(null)
+      ctx.setFilter(makeDefaultFilter())
+      ctx.setSort('status', 'asc')
       ctx.rerender()
     })
-    pill.addEventListener('contextmenu', (e) => {
-      e.preventDefault()
-      const menu = new Menu()
-      menu.addItem((item) =>
-        item
-          .setTitle('Update with current filters')
-          .setIcon('refresh-cw')
-          .onClick(
-            safeAsync(async () => {
-              sv.filter = { ...ctx.filter }
-              sv.sortKey = ctx.sortKey
-              sv.sortDir = ctx.sortDir
-              await ctx.plugin.store.saveProject(ctx.project)
-              ctx.rerender()
-            })
-          )
-      )
-      menu.addItem((item) =>
-        item
-          .setTitle('Delete view')
-          .setIcon('trash')
-          .onClick(
-            safeAsync(async () => {
-              ctx.project.savedViews = ctx.project.savedViews.filter((v) => v.id !== sv.id)
-              if (ctx.activeSavedViewId === sv.id) ctx.setActiveSavedViewId(null)
-              await ctx.plugin.store.saveProject(ctx.project)
-              ctx.rerender()
-            })
-          )
-      )
-      menu.showAtMouseEvent(e)
-    })
+
+  for (const sv of ctx.project.savedViews) {
+    new Pill(bar)
+      .setLabel(sv.name)
+      .setShape('pill')
+      .setActive(ctx.activeSavedViewId === sv.id)
+      .onClick(() => {
+        ctx.setActiveSavedViewId(sv.id)
+        ctx.setFilter({ ...sv.filter })
+        ctx.setSort(sv.sortKey, sv.sortDir)
+        ctx.rerender()
+      })
+      .onContextMenu((e) => {
+        e.preventDefault()
+        const menu = new Menu()
+        menu.addItem((item) =>
+          item
+            .setTitle('Update with current filters')
+            .setIcon('refresh-cw')
+            .onClick(
+              safeAsync(async () => {
+                sv.filter = { ...ctx.filter }
+                sv.sortKey = ctx.sortKey
+                sv.sortDir = ctx.sortDir
+                await ctx.plugin.store.saveProject(ctx.project)
+                ctx.rerender()
+              })
+            )
+        )
+        menu.addItem((item) =>
+          item
+            .setTitle('Delete view')
+            .setIcon('trash')
+            .onClick(
+              safeAsync(async () => {
+                ctx.project.savedViews = ctx.project.savedViews.filter((v) => v.id !== sv.id)
+                if (ctx.activeSavedViewId === sv.id) ctx.setActiveSavedViewId(null)
+                await ctx.plugin.store.saveProject(ctx.project)
+                ctx.rerender()
+              })
+            )
+        )
+        menu.showAtMouseEvent(e)
+      })
   }
 
-  // "+ Save View" button
+  // "+ Save View" action
   if (hasActiveFilters(ctx.filter)) {
-    const saveBtn = bar.createEl('button', { text: '+ save view', cls: 'pm-saved-view-pill pm-saved-view-pill--save' })
-    saveBtn.addEventListener('click', () => {
+    const saveBtn = new ButtonComponent(bar).setButtonText('+ save view').onClick(() => {
       // Replace button with inline input (prompt() doesn't work in Electron)
-      saveBtn.addClass('pm-hidden')
+      saveBtn.buttonEl.addClass('pm-hidden')
       const wrapper = bar.createDiv('pm-saved-view-inline-input')
       const input = wrapper.createEl('input', {
         type: 'text',
@@ -108,7 +112,7 @@ export function renderSavedViewsBar(container: HTMLElement, ctx: SavedViewsConte
         const name = input.value.trim()
         if (!name) {
           wrapper.remove()
-          saveBtn.removeClass('pm-hidden')
+          saveBtn.buttonEl.removeClass('pm-hidden')
           return
         }
         const sv: SavedView = {
@@ -131,14 +135,14 @@ export function renderSavedViewsBar(container: HTMLElement, ctx: SavedViewsConte
         }
         if (e.key === 'Escape') {
           wrapper.remove()
-          saveBtn.removeClass('pm-hidden')
+          saveBtn.buttonEl.removeClass('pm-hidden')
         }
       })
       input.addEventListener('blur', () => {
         if (input.value.trim()) commit()
         else {
           wrapper.remove()
-          saveBtn.removeClass('pm-hidden')
+          saveBtn.buttonEl.removeClass('pm-hidden')
         }
       })
     })

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -14,6 +14,7 @@ import { today, parsePlainDate } from '../../dates'
 import { COLOR_ACCENT } from '../../constants'
 import { renderStatusBadge, renderPriorityBadge } from '../../ui/StatusBadge'
 import { openTaskModal } from '../../ui/ModalFactory'
+import { Badge } from '../../ui/primitives/Badge'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
 import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext } from './TableRenderer'
@@ -157,20 +158,16 @@ export function renderTitleCell(row: HTMLElement, task: Task, depth: number, ctx
   })
 
   if (task.type === 'milestone') {
-    cell.createEl('span', { text: 'M', cls: 'pm-task-badge pm-task-badge--milestone', attr: { title: 'Milestone' } })
+    new Badge(cell).setLabel('M').setSize('sm').setColor('var(--color-purple)').setTooltip('Milestone')
   }
   if (task.type === 'subtask') {
-    cell.createEl('span', { text: 'Sub', cls: 'pm-task-badge pm-task-badge--subtask', attr: { title: 'Subtask' } })
+    new Badge(cell).setLabel('Sub').setSize('sm').setColor('var(--color-green)').setTooltip('Subtask')
   }
   if (task.recurrence) {
-    cell.createEl('span', { text: 'R', cls: 'pm-task-badge pm-task-badge--recurrence', attr: { title: 'Recurring' } })
+    new Badge(cell).setLabel('R').setSize('sm').setColor('var(--color-blue)').setTooltip('Recurring')
   }
   if (task.archived) {
-    cell.createEl('span', {
-      text: 'Archived',
-      cls: 'pm-task-badge pm-task-badge--archived',
-      attr: { title: 'Archived' }
-    })
+    new Badge(cell).setLabel('Archived').setSize('sm').setColor('var(--text-muted)').setTooltip('Archived')
   }
 
   if (task.tags.length) {

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -15,6 +15,7 @@ import { renderStatusBadge, renderPriorityBadge } from '../../ui/StatusBadge'
 import { openTaskModal } from '../../ui/ModalFactory'
 import { AvatarStack } from '../../ui/primitives/AvatarStack'
 import { Badge } from '../../ui/primitives/Badge'
+import { Chip } from '../../ui/primitives/Chip'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
 import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext } from './TableRenderer'
@@ -173,7 +174,7 @@ export function renderTitleCell(row: HTMLElement, task: Task, depth: number, ctx
   if (task.tags.length) {
     const tagRow = cell.createDiv('pm-table-tags')
     for (const tag of task.tags) {
-      tagRow.createEl('span', { text: tag, cls: 'pm-tag' })
+      new Chip(tagRow).setLabel(tag).setShape('pill')
     }
   }
 }

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -17,6 +17,7 @@ import { AvatarStack } from '../../ui/primitives/AvatarStack'
 import { Badge } from '../../ui/primitives/Badge'
 import { Chip } from '../../ui/primitives/Chip'
 import { DueDateChip } from '../../ui/primitives/DueDateChip'
+import { ProgressBar } from '../../ui/primitives/ProgressBar'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
 import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext } from './TableRenderer'
@@ -260,12 +261,10 @@ export function renderDueDateCell(row: HTMLElement, task: Task, ctx: TableContex
 
 export function renderProgressCell(row: HTMLElement, task: Task, statusColor: string | undefined): void {
   const cell = row.createEl('td', { cls: 'pm-table-cell pm-table-cell-progress' })
-  const wrap = cell.createDiv('pm-progress-wrap')
-  const bar = wrap.createDiv('pm-progress-bar')
-  const fill = bar.createDiv('pm-progress-fill')
-  fill.style.width = `${task.progress}%`
-  fill.style.background = statusColor ?? COLOR_ACCENT
-  wrap.createEl('span', { text: `${task.progress}%`, cls: 'pm-progress-label' })
+  new ProgressBar(cell)
+    .setValue(task.progress)
+    .setColor(statusColor ?? COLOR_ACCENT)
+    .setShowLabel(true)
 }
 
 export function renderTimeCell(row: HTMLElement, task: Task): void {

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -2,7 +2,6 @@ import { Menu } from 'obsidian'
 import type { Task, Project } from '../../types'
 import { totalLoggedHours } from '../../store/TaskTreeOps'
 import {
-  stringToColor,
   formatDateLong,
   isTaskOverdue,
   getStatusConfig,
@@ -14,6 +13,7 @@ import { today, parsePlainDate } from '../../dates'
 import { COLOR_ACCENT } from '../../constants'
 import { renderStatusBadge, renderPriorityBadge } from '../../ui/StatusBadge'
 import { openTaskModal } from '../../ui/ModalFactory'
+import { AvatarStack } from '../../ui/primitives/AvatarStack'
 import { Badge } from '../../ui/primitives/Badge'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
 import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
@@ -212,18 +212,7 @@ export function renderPriorityCell(row: HTMLElement, task: Task, ctx: TableConte
 
 export function renderAssigneesCell(row: HTMLElement, task: Task): void {
   const cell = row.createEl('td', { cls: 'pm-table-cell pm-table-cell-assignees' })
-  for (const a of task.assignees.slice(0, 3)) {
-    const avatar = cell.createEl('span', { cls: 'pm-avatar' })
-    avatar.textContent = a.slice(0, 2).toUpperCase()
-    avatar.title = a
-    avatar.style.background = stringToColor(a)
-  }
-  if (task.assignees.length > 3) {
-    cell.createEl('span', {
-      text: `+${task.assignees.length - 3}`,
-      cls: 'pm-avatar pm-avatar-more'
-    })
-  }
+  new AvatarStack(cell).setNames(task.assignees).setMax(3)
 }
 
 function startDueDateEdit(cell: HTMLElement, display: HTMLElement, task: Task, ctx: TableContext): void {

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -16,6 +16,7 @@ import { openTaskModal } from '../../ui/ModalFactory'
 import { AvatarStack } from '../../ui/primitives/AvatarStack'
 import { Badge } from '../../ui/primitives/Badge'
 import { Chip } from '../../ui/primitives/Chip'
+import { DueDateChip } from '../../ui/primitives/DueDateChip'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
 import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext } from './TableRenderer'
@@ -234,11 +235,13 @@ export function renderDueDateCell(row: HTMLElement, task: Task, ctx: TableContex
   const cell = row.createEl('td', { cls: 'pm-table-cell' })
 
   if (!task.due) {
-    const placeholder = cell.createEl('span', { text: '\u2014', cls: 'pm-due-placeholder' })
-    placeholder.addEventListener('click', (e) => {
-      e.stopPropagation()
-      startDueDateEdit(cell, placeholder, task, ctx)
-    })
+    const chip = new DueDateChip(cell)
+      .setLabel('\u2014')
+      .setPlaceholder(true)
+      .onClick((e) => {
+        e.stopPropagation()
+        startDueDateEdit(cell, chip.el, task, ctx)
+      })
     return
   }
 
@@ -246,17 +249,13 @@ export function renderDueDateCell(row: HTMLElement, task: Task, ctx: TableContex
   const overdue = isTaskOverdue(task, ctx.plugin.settings.statuses)
   const isNear = !overdue && due !== null && due.since(today(), { largestUnit: 'days' }).days < 3
 
-  const chip = cell.createEl('span', {
-    text: formatDateLong(task.due),
-    cls: 'pm-due-chip'
-  })
-  if (overdue) chip.addClass('pm-due-chip--overdue')
-  else if (isNear) chip.addClass('pm-due-chip--near')
-
-  chip.addEventListener('click', (e) => {
-    e.stopPropagation()
-    startDueDateEdit(cell, chip, task, ctx)
-  })
+  const chip = new DueDateChip(cell)
+    .setLabel(formatDateLong(task.due))
+    .setUrgency(overdue ? 'overdue' : isNear ? 'near' : 'normal')
+    .onClick((e) => {
+      e.stopPropagation()
+      startDueDateEdit(cell, chip.el, task, ctx)
+    })
 }
 
 export function renderProgressCell(row: HTMLElement, task: Task, statusColor: string | undefined): void {

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -37,9 +37,7 @@ export function renderTaskRow(
   row.addEventListener('click', (e) => {
     const target = e.target as HTMLElement
     if (
-      target.closest(
-        'button, input, .pm-badge--interactive, .pm-task-title-text, .pm-due-chip, .pm-due-placeholder, .pm-table-cell-select'
-      )
+      target.closest('button, input, .pm-badge--interactive, .pm-task-title-text, .pm-due-chip, .pm-table-cell-select')
     ) {
       return
     }

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -38,7 +38,7 @@ export function renderTaskRow(
     const target = e.target as HTMLElement
     if (
       target.closest(
-        'button, input, .pm-status-badge, .pm-priority-badge, .pm-task-title-text, .pm-due-chip, .pm-due-placeholder, .pm-table-cell-select'
+        'button, input, .pm-badge--interactive, .pm-task-title-text, .pm-due-chip, .pm-due-placeholder, .pm-table-cell-select'
       )
     ) {
       return

--- a/styles.css
+++ b/styles.css
@@ -113,48 +113,6 @@
 }
 .pm-view-btn-icon { font-size: 14px; }
 
-/* ── Buttons ─────────────────────────────────────────────────────────────── */
-.pm-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 14px;
-  border: none;
-  border-radius: var(--pm-radius-sm);
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 500;
-  transition: all 0.15s;
-  white-space: nowrap;
-}
-.pm-btn:focus-visible { outline: 2px solid var(--pm-accent); outline-offset: 2px; }
-
-.pm-btn-primary {
-  background: linear-gradient(180deg, var(--pm-accent), var(--pm-accent-dim));
-  color: #fff;
-}
-.pm-btn-primary:hover { background: linear-gradient(180deg, var(--pm-accent-dim), var(--pm-accent-dim)); box-shadow: 0 2px 8px rgba(139,114,190,0.25); }
-.pm-btn-primary:active { box-shadow: none; }
-
-.theme-light .pm-btn-primary {
-  background: transparent;
-  color: var(--pm-accent);
-  border: 1px solid color-mix(in srgb, var(--pm-accent) 40%, transparent);
-}
-.theme-light .pm-btn-primary:hover {
-  background: var(--pm-accent-light);
-  box-shadow: none;
-}
-
-.pm-btn-ghost { background: transparent; color: var(--pm-text-muted); }
-.pm-btn-ghost:hover { background: var(--pm-bg3); color: var(--pm-text); }
-
-.pm-btn-danger { background: transparent; color: var(--pm-danger); }
-.pm-btn-danger:hover { background: rgba(196,112,112,0.1); }
-
-.pm-btn-icon { padding: 6px 8px; }
-.pm-btn-sm { padding: 3px 8px; font-size: 12px; }
-
 .pm-prop-add-btn {
   background: transparent;
   border: 1px dashed var(--pm-border);
@@ -1889,9 +1847,6 @@
 .pm-offscreen { position: fixed; opacity: 0; pointer-events: none; }
 .pm-no-shrink { flex-shrink: 0; }
 body.pm-resize-active, body.pm-resize-active * { cursor: col-resize !important; user-select: none !important; }
-
-/* Confirm button (modal) */
-.pm-btn-confirm-danger { background: var(--background-modifier-error); color: var(--text-on-accent); }
 
 /* Prompt / Confirm modal typography */
 .pm-prompt-text,

--- a/styles.css
+++ b/styles.css
@@ -180,17 +180,6 @@
 .pm-project-card-meta { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
 .pm-project-card-tasks { font-size: 12px; color: var(--pm-text-muted); }
 
-.pm-project-card-progress {
-  height: 4px;
-  background: var(--background-modifier-border);
-  border-radius: 99px;
-  overflow: hidden;
-}
-.pm-project-card-progress-fill {
-  height: 100%;
-  border-radius: 99px;
-  transition: width 0.4s ease;
-}
 
 /* ═══════════════════════════════════════════════════════════════════════════
    TABLE VIEW
@@ -519,11 +508,31 @@
   background: transparent;
 }
 
-/* Progress */
-.pm-progress-wrap { display: flex; align-items: center; gap: 8px; }
-.pm-progress-bar { flex: 1; height: 6px; background: var(--background-modifier-border); border-radius: 99px; overflow: hidden; }
-.pm-progress-fill { height: 100%; border-radius: 99px; transition: width 0.3s ease; }
-.pm-progress-label { font-size: 11px; color: var(--pm-text-muted); min-width: 28px; }
+/* ── ProgressBar ──────────────────────────────────────────────────────── */
+.pm-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pm-progress-track {
+  flex: 1;
+  height: 6px;
+  background: var(--background-modifier-border);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.pm-progress--sm .pm-progress-track { height: 3px; }
+.pm-progress-fill {
+  height: 100%;
+  border-radius: 99px;
+  background: var(--pm-progress-color, var(--interactive-accent));
+  transition: width 0.3s ease;
+}
+.pm-progress-label {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  min-width: 28px;
+}
 
 /* Row menu */
 .pm-row-menu-btn {
@@ -954,14 +963,6 @@
   justify-content: space-between;
   gap: 8px;
 }
-
-.pm-kanban-card-pbar {
-  height: 3px;
-  background: var(--pm-bg3);
-  border-radius: 99px;
-  overflow: hidden;
-}
-.pm-kanban-card-pbar-fill { height: 100%; border-radius: 99px; background: var(--pm-accent); }
 
 .pm-kanban-card-subtasks { font-size: 11px; color: var(--pm-text-muted); }
 .pm-kanban-card-parent {

--- a/styles.css
+++ b/styles.css
@@ -503,10 +503,6 @@
   background: transparent;
   font-size: var(--font-ui-smaller);
 }
-.pm-due-chip--label.pm-due-chip--near,
-.pm-due-chip--label.pm-due-chip--overdue {
-  background: transparent;
-}
 
 /* ── ProgressBar ──────────────────────────────────────────────────────── */
 .pm-progress {

--- a/styles.css
+++ b/styles.css
@@ -449,7 +449,7 @@
   letter-spacing: 0;
 }
 
-/* Avatar */
+/* ── Avatar ───────────────────────────────────────────────────────────── */
 .pm-avatar {
   display: inline-flex;
   align-items: center;
@@ -459,13 +459,18 @@
   border-radius: 50%;
   font-size: 10px;
   font-weight: 700;
-  color: #fff;
-  margin-right: -6px;
-  border: 2px solid var(--pm-bg);
+  color: var(--text-on-accent);
+  border: 2px solid var(--background-primary);
   flex-shrink: 0;
 }
 .pm-avatar--sm { width: 22px; height: 22px; font-size: 9px; }
-.pm-avatar-more { background: var(--pm-bg3); color: var(--pm-text-muted); font-size: 10px; }
+.pm-avatar--more {
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-size: 10px;
+}
+.pm-avatar-stack { display: inline-flex; align-items: center; }
+.pm-avatar-stack > .pm-avatar:not(:first-child) { margin-left: -6px; }
 
 /* Due date chip */
 .pm-due-chip {
@@ -906,7 +911,6 @@
   justify-content: space-between;
   gap: 8px;
 }
-.pm-kanban-card-avatars { display: flex; }
 
 .pm-kanban-due {
   font-size: 11px;

--- a/styles.css
+++ b/styles.css
@@ -419,26 +419,34 @@
 
 .pm-table-tags { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px; }
 
-/* Badges */
-.pm-status-badge, .pm-priority-badge {
+/* ── Badge ────────────────────────────────────────────────────────────── */
+.pm-badge {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   padding: 3px 8px;
-  border-radius: var(--pm-radius-sm);
-  font-size: 11px;
+  border-radius: var(--radius-s);
+  font-size: var(--font-ui-smaller);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  cursor: pointer;
-  border: 1px solid color-mix(in srgb, var(--badge-color) 30%, transparent);
-  background: color-mix(in srgb, var(--badge-color) 8%, transparent);
-  color: var(--badge-color);
+  border: 1px solid color-mix(in srgb, var(--pm-badge-color, var(--text-muted)) 30%, transparent);
+  background: color-mix(in srgb, var(--pm-badge-color, var(--text-muted)) 8%, transparent);
+  color: var(--pm-badge-color, var(--text-muted));
   white-space: nowrap;
+  line-height: 1.2;
   transition: background 0.15s;
 }
-.pm-status-badge:hover, .pm-priority-badge:hover {
-  background: color-mix(in srgb, var(--badge-color) 16%, transparent);
+.pm-badge--interactive { cursor: pointer; }
+.pm-badge--interactive:hover {
+  background: color-mix(in srgb, var(--pm-badge-color, var(--text-muted)) 16%, transparent);
+}
+.pm-badge--sm {
+  padding: 1px 5px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 /* Avatar */
@@ -1027,27 +1035,6 @@
 }
 
 .pm-prop-value { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
-.pm-prop-value--badge {
-  all: unset;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  border-radius: var(--pm-radius-sm, 0.25rem);
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border: 1px solid color-mix(in srgb, var(--badge-color) 30%, transparent);
-  background: color-mix(in srgb, var(--badge-color) 8%, transparent);
-  color: var(--badge-color);
-  white-space: nowrap;
-  transition: background 0.15s;
-}
-.pm-prop-value--badge:hover {
-  background: color-mix(in srgb, var(--badge-color) 16%, transparent);
-}
 
 .pm-prop-progress-wrap {
   display: flex;
@@ -1649,45 +1636,6 @@
 .pm-modal-header {
   background: var(--background-primary);
   border-bottom-color: var(--pm-border, var(--background-modifier-border));
-}
-
-/* ── Task badges (replace emojis) ────────────────────────────────────── */
-.pm-task-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 4px;
-  font-size: 10px;
-  font-weight: 700;
-  flex-shrink: 0;
-  line-height: 1;
-}
-.pm-task-badge--milestone {
-  background: rgba(139,114,190,0.15);
-  color: #69519a;
-  border: 1px solid rgba(139,114,190,0.3);
-}
-.pm-task-badge--recurrence {
-  background: rgba(74,126,184,0.15);
-  color: #4a7eb8;
-  border: 1px solid rgba(74,126,184,0.3);
-}
-.pm-task-badge--archived {
-  background: rgba(138,148,160,0.15);
-  color: #8a94a0;
-  border: 1px solid rgba(138,148,160,0.3);
-  width: auto;
-  height: auto;
-  padding: 1px 6px;
-}
-.pm-task-badge--subtask {
-  background: rgba(121,181,141,0.15);
-  color: #79b58d;
-  border: 1px solid rgba(121,181,141,0.3);
-  width: auto;
-  padding: 1px 5px;
 }
 
 /* ── Properties container ────────────────────────────────────────────── */

--- a/styles.css
+++ b/styles.css
@@ -472,30 +472,52 @@
 .pm-avatar-stack { display: inline-flex; align-items: center; }
 .pm-avatar-stack > .pm-avatar:not(:first-child) { margin-left: -6px; }
 
-/* Due date chip */
+/* ── DueDateChip ──────────────────────────────────────────────────────── */
 .pm-due-chip {
   display: inline-block;
   padding: 3px 7px;
-  border-radius: var(--pm-radius-sm);
-  font-size: 12px;
-  background: var(--pm-bg2);
-  color: var(--pm-text-muted);
+  border-radius: var(--radius-s);
+  font-size: var(--font-ui-smaller);
+  background: var(--background-secondary);
+  color: var(--text-muted);
   white-space: nowrap;
-  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
 }
-.pm-due-chip:hover { background: var(--pm-bg3); }
-.pm-due-chip--near { background: rgba(245,158,11,0.15); color: var(--pm-warning); }
-.pm-due-chip--near:hover { background: rgba(245,158,11,0.22); }
-.pm-due-chip--overdue { background: rgba(196,112,112,0.15); color: var(--pm-danger); font-weight: 600; }
-.pm-due-chip--overdue:hover { background: rgba(196,112,112,0.22); }
-.pm-due-placeholder {
-  color: var(--pm-text-faint);
-  cursor: pointer;
-  padding: 3px 7px;
-  border-radius: var(--pm-radius-sm);
-  font-size: 12px;
+.pm-due-chip--interactive { cursor: pointer; }
+.pm-due-chip--interactive:hover { background: var(--background-modifier-hover); }
+.pm-due-chip--placeholder {
+  background: transparent;
+  color: var(--text-faint);
 }
-.pm-due-placeholder:hover { background: var(--pm-bg3); color: var(--pm-text-muted); }
+.pm-due-chip--placeholder.pm-due-chip--interactive:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-muted);
+}
+.pm-due-chip--near {
+  background: color-mix(in srgb, var(--color-orange) 18%, transparent);
+  color: var(--color-orange);
+}
+.pm-due-chip--near.pm-due-chip--interactive:hover {
+  background: color-mix(in srgb, var(--color-orange) 28%, transparent);
+}
+.pm-due-chip--overdue {
+  background: color-mix(in srgb, var(--color-red) 18%, transparent);
+  color: var(--color-red);
+  font-weight: 600;
+}
+.pm-due-chip--overdue.pm-due-chip--interactive:hover {
+  background: color-mix(in srgb, var(--color-red) 28%, transparent);
+}
+.pm-due-chip--label {
+  display: inline;
+  padding: 0;
+  background: transparent;
+  font-size: var(--font-ui-smaller);
+}
+.pm-due-chip--label.pm-due-chip--near,
+.pm-due-chip--label.pm-due-chip--overdue {
+  background: transparent;
+}
 
 /* Progress */
 .pm-progress-wrap { display: flex; align-items: center; gap: 8px; }
@@ -932,12 +954,6 @@
   justify-content: space-between;
   gap: 8px;
 }
-
-.pm-kanban-due {
-  font-size: 11px;
-  color: var(--pm-text-muted);
-}
-.pm-kanban-due--overdue { color: var(--pm-danger); font-weight: 600; }
 
 .pm-kanban-card-pbar {
   height: 3px;

--- a/styles.css
+++ b/styles.css
@@ -537,23 +537,44 @@
 .pm-add-subtask-btn:hover { background: var(--pm-bg3); color: var(--pm-accent); }
 
 /* Tags */
-.pm-tag {
-  display: inline-block;
-  padding: 2px 7px;
-  background: var(--pm-bg3);
-  border-radius: 99px;
-  font-size: 11px;
-  color: var(--pm-text-muted);
+/* ── Chip ─────────────────────────────────────────────────────────────── */
+.pm-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--radius-s);
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  background: var(--background-modifier-hover);
+  border: 1px solid transparent;
   white-space: nowrap;
 }
-.pm-tag--sm { padding: 1px 5px; font-size: 10px; }
-.pm-tag--removable { display: inline-flex; align-items: center; gap: 4px; }
-.pm-tag-rm {
-  background: transparent; border: none; cursor: pointer;
-  color: var(--pm-text-muted); font-size: 10px; padding: 0;
-  line-height: 1;
+.pm-chip--pill { border-radius: 99px; }
+.pm-chip--sm { padding: 1px 6px; font-size: 10px; }
+.pm-chip--accent {
+  background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+  color: var(--text-accent);
+  border-color: color-mix(in srgb, var(--interactive-accent) 25%, transparent);
 }
-.pm-tag-rm:hover { color: var(--pm-danger); }
+.pm-chip-rm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  opacity: 0.6;
+}
+.pm-chip-rm:hover {
+  opacity: 1;
+  color: var(--text-error, var(--color-red));
+}
+.pm-chip-rm svg { width: 12px; height: 12px; }
 .pm-suggest-create { color: var(--text-accent); font-style: italic; }
 
 /* Add task row */
@@ -1093,50 +1114,6 @@
 .pm-prop-text:focus, .pm-prop-select:focus { border-color: var(--pm-accent); outline: none; }
 
 .pm-prop-assignees, .pm-prop-tags, .pm-prop-deps { flex-wrap: wrap; }
-
-.pm-assignee-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  background: var(--pm-accent-light);
-  border-radius: 99px;
-  font-size: 12px;
-  color: var(--pm-accent);
-  border: 1px solid rgba(139,114,190,0.25);
-}
-.pm-assignee-chip-rm {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--pm-accent);
-  font-size: 10px;
-  padding: 0;
-  line-height: 1;
-  opacity: 0.7;
-}
-.pm-assignee-chip-rm:hover { opacity: 1; }
-
-.pm-dep-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  background: var(--pm-bg3);
-  border-radius: var(--pm-radius-sm);
-  font-size: 12px;
-  color: var(--pm-text-muted);
-  border: 1px solid var(--pm-border);
-}
-.pm-dep-chip-rm {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--pm-text-muted);
-  font-size: 10px;
-  padding: 0;
-}
-.pm-dep-chip-rm:hover { color: var(--pm-danger); }
 
 /* Modal sections */
 .pm-modal-section { padding: 14px 24px; border-top: 1px solid var(--pm-border); }

--- a/styles.css
+++ b/styles.css
@@ -262,63 +262,41 @@
   flex-wrap: wrap;
   flex-shrink: 0;
 }
-.pm-saved-view-pill {
-  padding: 4px 12px;
-  border-radius: 99px;
-  font-size: 12px;
+/* ── Pill ─────────────────────────────────────────────────────────────────── */
+.pm-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: var(--radius-s);
+  font-size: var(--font-ui-smaller);
   font-weight: 500;
   cursor: pointer;
-  border: 1px solid var(--pm-border);
+  border: 1px solid var(--background-modifier-border);
   background: transparent;
-  color: var(--pm-text-muted);
-  transition: all 0.15s;
+  color: var(--text-muted);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
 }
-.pm-saved-view-pill:hover {
-  background: var(--pm-bg3);
-  color: var(--pm-text);
+.pm-pill:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
 }
-.pm-saved-view-pill--active {
-  background: var(--pm-accent);
-  color: #fff;
-  border-color: var(--pm-accent);
+.pm-pill:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
 }
-.pm-saved-view-pill--save {
-  border-style: dashed;
-  color: var(--pm-accent);
-  border-color: color-mix(in srgb, var(--pm-accent) 40%, transparent);
+.pm-pill--active {
+  background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--interactive-accent) 40%, transparent);
+  color: var(--text-accent);
 }
-.pm-saved-view-pill--save:hover {
-  background: var(--pm-accent-light);
-  border-style: solid;
-}
+.pm-pill--pill { border-radius: 99px; }
 
 /* ── Selected Row ─────────────────────────────────────────────────────────── */
 .pm-table-row--selected {
   background: color-mix(in srgb, var(--pm-accent) 10%, transparent) !important;
   box-shadow: inset 3px 0 0 var(--pm-accent);
-}
-
-/* ── Filter Dropdown Buttons ──────────────────────────────────────────────── */
-.pm-filter-dropdown-btn {
-  padding: 4px 10px;
-  border-radius: var(--pm-radius-sm);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  border: 1px solid var(--pm-border);
-  background: transparent;
-  color: var(--pm-text-muted);
-  transition: all 0.15s;
-  white-space: nowrap;
-}
-.pm-filter-dropdown-btn:hover {
-  background: var(--pm-bg3);
-  color: var(--pm-text);
-}
-.pm-filter-dropdown-btn--active {
-  background: var(--pm-accent-light);
-  border-color: color-mix(in srgb, var(--pm-accent) 40%, transparent);
-  color: var(--pm-accent);
 }
 
 .pm-filter-bar {


### PR DESCRIPTION
Replaces our custom CSS classes (`.pm-btn-*`, `.pm-saved-view-pill`, `.pm-filter-dropdown-btn`, `.pm-status-badge`, `.pm-task-badge--*`, `.pm-tag`, `.pm-assignee-chip`, `.pm-dep-chip`, `.pm-avatar`, `.pm-due-chip`, `.pm-kanban-due`, `.pm-progress-*`) with seven primitives at `src/ui/primitives/`. They only use Obsidian's CSS variables, so the UI picks up the user's theme accent (`--interactive-accent`) and palette tokens (`--color-red/orange/green/blue/purple`) instead of the hardcoded `#8b72be` family. Chained-setter API matching `ButtonComponent`.


## Visible changes
- Bulk-action bar, gantt toolbar, and filter clear button are native-sized now. Used to be `pm-btn-sm`, so the bars feel less dense.
- Saved-view tabs lost the bold filled-accent active style; they share the soft accent with filter pills now. `+ save view` is a regular native button (no more dashed border).
- Task-type indicators (M / R / Sub / Archived) aren't 18px squares anymore. Small text-fitting badges using `--color-purple/green/blue` and `--text-muted`.
- Status / priority badges in the task modal are spans, not buttons. Same click-to-open-menu, but no tab focus ring (spans aren't focusable).
- Single avatars don't have the 6px phantom right margin anymore. Was visible in the project-modal team list. Stack overlap still works inside `AvatarStack`.
- Kanban shows `+N` when a task has 4+ assignees. Used to silently drop them.
- Chip remove buttons render lucide `x` icons. Red on hover.
- Confirm-modal "Delete" uses pure `.mod-warning`. Custom override is gone.
- Light theme primary buttons use native `.mod-cta` instead of the transparent-with-border variant we had.