### PR TITLE
don't create task when modal is closed without saving

### DIFF
--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -58,7 +58,7 @@ export class TaskModal extends Modal {
   }
 
   onClose(): void {
-    if (!this.cancelled && !this.saved && this.task.title.trim()) {
+    if (!this.isNew && !this.cancelled && !this.saved && this.task.title.trim()) {
       void this.persistTask()
     }
     this.noteSuggest?.destroy()


### PR DESCRIPTION
Closing the new-task modal via Esc or the X button persisted the task if the title field was non-empty. Now only existing-task edits auto-save on close; new tasks require clicking Create.