### PR TITLE
split ProjectListRenderer into composite and primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- UI now follows the Obsidian theme: accent color, near/overdue colors, badge palette, and avatars all read from Obsidian CSS variables instead of the previous hardcoded purple
+- Toolbar, gantt, filter, and bulk-action buttons render at native size (previously compact)
+- Saved-view tabs share the soft accent treatment with filter pills (previously filled accent)
+- `+ save view` and inline chip-list add buttons are native buttons (no longer dashed pills)
+- Status and priority badges in the task modal are spans, no longer keyboard-focusable
+- Confirm "Delete" uses Obsidian's native warning style
+- Light-theme primary buttons use solid accent (`mod-cta`) instead of the bordered variant
+- Project view header gear, bulk-action clear, and chip remove buttons use lucide icons
+- Chip remove buttons turn red on hover, uniformly across tags, assignees, and dependencies
+- Project-card and kanban-card progress bars are 3px tall
+
+### Fixed
+
+- Phantom 6px right margin on solo avatars (visible in the project edit modal)
+- Kanban cards silently dropping the 4th+ assignee (now shown as `+N`)
+- Duplicate task entries when creating a task
+
 ## [1.4.0] - 2026-04-29
 
 ### Breaking Changes

--- a/src/ui/composites/ProjectCard.ts
+++ b/src/ui/composites/ProjectCard.ts
@@ -1,0 +1,39 @@
+import { ProgressBar } from '../primitives/ProgressBar'
+
+export interface ProjectCardProps {
+  title: string
+  icon: string
+  color: string
+  tasksDone: number
+  tasksTotal: number
+  onClick: () => void
+  onContextMenu: (e: MouseEvent) => void
+}
+
+export class ProjectCard {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement, props: ProjectCardProps) {
+    const card = parentEl.createDiv('pm-project-card')
+    this.el = card
+
+    const colorBar = card.createDiv('pm-project-card-bar')
+    colorBar.setCssStyles({ background: props.color })
+
+    const body = card.createDiv('pm-project-card-body')
+    body.createEl('div', { text: props.icon, cls: 'pm-project-card-icon' })
+    body.createEl('h3', { text: props.title, cls: 'pm-project-card-title' })
+
+    const meta = body.createDiv('pm-project-card-meta')
+    meta.createEl('span', {
+      text: `${props.tasksDone}/${props.tasksTotal} tasks`,
+      cls: 'pm-project-card-tasks'
+    })
+
+    const percent = props.tasksTotal ? (props.tasksDone / props.tasksTotal) * 100 : 0
+    new ProgressBar(body).setSize('sm').setValue(percent).setColor(props.color)
+
+    card.addEventListener('click', () => props.onClick())
+    card.addEventListener('contextmenu', (e) => props.onContextMenu(e))
+  }
+}

--- a/src/ui/primitives/EmptyState.ts
+++ b/src/ui/primitives/EmptyState.ts
@@ -1,0 +1,38 @@
+import { ButtonComponent } from 'obsidian'
+
+export class EmptyState {
+  el: HTMLElement
+  private iconEl?: HTMLElement
+  private titleEl?: HTMLElement
+  private bodyEl?: HTMLElement
+  private actionEl?: HTMLElement
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createDiv('pm-empty-state')
+  }
+
+  setIcon(text: string): this {
+    this.iconEl ??= this.el.createDiv('pm-empty-icon')
+    this.iconEl.setText(text)
+    return this
+  }
+
+  setTitle(text: string): this {
+    this.titleEl ??= this.el.createEl('h3')
+    this.titleEl.setText(text)
+    return this
+  }
+
+  setBody(text: string): this {
+    this.bodyEl ??= this.el.createEl('p')
+    this.bodyEl.setText(text)
+    return this
+  }
+
+  setAction(label: string, onClick: () => void): this {
+    if (!this.actionEl) this.actionEl = this.el.createDiv('pm-empty-action')
+    this.actionEl.empty()
+    new ButtonComponent(this.actionEl).setButtonText(label).setCta().onClick(onClick)
+    return this
+  }
+}

--- a/src/views/ProjectListRenderer.ts
+++ b/src/views/ProjectListRenderer.ts
@@ -1,9 +1,10 @@
-import { ButtonComponent, TFile, Menu } from 'obsidian'
+import { TFile, Menu, ButtonComponent } from 'obsidian'
 import type PMPlugin from '../main'
-import type { Task, StatusConfig } from '../types'
+import type { Project, Task, StatusConfig } from '../types'
 import { safeAsync, isTerminalStatus } from '../utils'
 import { openProjectModal } from '../ui/ModalFactory'
-import { ProgressBar } from '../ui/primitives/ProgressBar'
+import { EmptyState } from '../ui/primitives/EmptyState'
+import { ProjectCard } from '../ui/composites/ProjectCard'
 
 export interface ProjectListContext {
   plugin: PMPlugin
@@ -20,101 +21,78 @@ export function renderProjectListToolbar(ctx: ProjectListContext): void {
   new ButtonComponent(ctx.toolbarEl)
     .setButtonText('+ new project')
     .setCta()
-    .onClick(() => {
-      openProjectModal(ctx.plugin, {
-        onSave: async (project) => {
-          const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
-          if (file instanceof TFile) await ctx.openProjectFile(file)
-        }
-      })
-    })
+    .onClick(() => openCreateProjectModal(ctx))
 }
 
 export async function renderProjectListContent(ctx: ProjectListContext): Promise<void> {
   const projects = await ctx.plugin.store.loadAllProjects(ctx.plugin.settings.projectsFolder)
-  // Abort if a project view has taken over since this async load started
   if (ctx.isStale()) return
   ctx.contentEl.empty()
 
   if (projects.length === 0) {
-    const empty = ctx.contentEl.createDiv('pm-empty-state')
-    empty.createEl('div', { text: '\ud83d\udccb', cls: 'pm-empty-icon' })
-    empty.createEl('h3', { text: 'No projects yet' })
-    empty.createEl('p', { text: 'Create your first project to get started.' })
-    new ButtonComponent(empty)
-      .setButtonText('+ new project')
-      .setCta()
-      .onClick(() => {
-        openProjectModal(ctx.plugin, {
-          onSave: async (project) => {
-            const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
-            if (file instanceof TFile) await ctx.openProjectFile(file)
-          }
-        })
-      })
+    new EmptyState(ctx.contentEl)
+      .setIcon('📋')
+      .setTitle('No projects yet')
+      .setBody('Create your first project to get started.')
+      .setAction('+ new project', () => openCreateProjectModal(ctx))
     return
   }
 
   const grid = ctx.contentEl.createDiv('pm-project-grid')
   for (const project of projects) {
-    const card = grid.createDiv('pm-project-card')
-    card.style.setProperty('--pm-project-color', project.color)
-
-    const colorBar = card.createDiv('pm-project-card-bar')
-    colorBar.style.background = project.color
-
-    const body = card.createDiv('pm-project-card-body')
-    body.createEl('div', { text: project.icon, cls: 'pm-project-card-icon' })
-    body.createEl('h3', { text: project.title, cls: 'pm-project-card-title' })
-
-    const meta = body.createDiv('pm-project-card-meta')
     const total = countTasks(project.tasks, false, ctx.plugin.settings.statuses)
     const done = countTasks(project.tasks, true, ctx.plugin.settings.statuses)
-    meta.createEl('span', { text: `${done}/${total} tasks`, cls: 'pm-project-card-tasks' })
-
-    new ProgressBar(body)
-      .setSize('sm')
-      .setValue(total ? (done / total) * 100 : 0)
-      .setColor(project.color)
-
-    card.addEventListener(
-      'click',
-      safeAsync(async () => {
+    new ProjectCard(grid, {
+      title: project.title,
+      icon: project.icon,
+      color: project.color,
+      tasksDone: done,
+      tasksTotal: total,
+      onClick: safeAsync(async () => {
         const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
         if (file instanceof TFile) await ctx.openProjectFile(file)
-      })
-    )
-
-    // Context menu
-    card.addEventListener('contextmenu', (e: MouseEvent) => {
-      const menu = new Menu()
-      menu.addItem((item) =>
-        item
-          .setTitle('Edit project')
-          .setIcon('settings')
-          .onClick(() => {
-            openProjectModal(ctx.plugin, {
-              project,
-              onSave: async () => {
-                await renderProjectListContent(ctx)
-              }
-            })
-          })
-      )
-      menu.addItem((item) =>
-        item
-          .setTitle('Delete project')
-          .setIcon('trash')
-          .onClick(
-            safeAsync(async () => {
-              await ctx.plugin.store.deleteProject(project)
-              await renderProjectListContent(ctx)
-            })
-          )
-      )
-      menu.showAtMouseEvent(e)
+      }),
+      onContextMenu: (e) => openProjectContextMenu(ctx, project, e)
     })
   }
+}
+
+function openCreateProjectModal(ctx: ProjectListContext): void {
+  openProjectModal(ctx.plugin, {
+    onSave: async (project) => {
+      const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
+      if (file instanceof TFile) await ctx.openProjectFile(file)
+    }
+  })
+}
+
+function openProjectContextMenu(ctx: ProjectListContext, project: Project, e: MouseEvent): void {
+  const menu = new Menu()
+  menu.addItem((item) =>
+    item
+      .setTitle('Edit project')
+      .setIcon('settings')
+      .onClick(() => {
+        openProjectModal(ctx.plugin, {
+          project,
+          onSave: async () => {
+            await renderProjectListContent(ctx)
+          }
+        })
+      })
+  )
+  menu.addItem((item) =>
+    item
+      .setTitle('Delete project')
+      .setIcon('trash')
+      .onClick(
+        safeAsync(async () => {
+          await ctx.plugin.store.deleteProject(project)
+          await renderProjectListContent(ctx)
+        })
+      )
+  )
+  menu.showAtMouseEvent(e)
 }
 
 function countTasks(tasks: Task[], doneOnly: boolean, statuses: StatusConfig[]): number {


### PR DESCRIPTION
Splits the project list view into a `ProjectCard` composite and a new `EmptyState` primitive. Internal refactor. No visual or behavior changes.

Also fills in the Unreleased changelog with UI changes from the prior kanban PR that didn't make it into that merge.