### PR TITLE
add TimeChip and IconButton primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Status and priority badges in the task modal are spans, no longer keyboard-focusable
 - Confirm "Delete" uses Obsidian's native warning style
 - Light-theme primary buttons use solid accent (`mod-cta`) instead of the bordered variant
-- Project view header gear, bulk-action clear, and chip remove buttons use lucide icons
+- Project view header gear, bulk-action clear, chip remove, and table row icon buttons use lucide icons
 - Chip remove buttons turn red on hover, uniformly across tags, assignees, and dependencies
 - Project-card and kanban-card progress bars are 3px tall
 

--- a/src/ui/composites/KanbanCard.ts
+++ b/src/ui/composites/KanbanCard.ts
@@ -5,6 +5,7 @@ import { Badge } from '../primitives/Badge'
 import { Chip } from '../primitives/Chip'
 import { DueDateChip } from '../primitives/DueDateChip'
 import { ProgressBar } from '../primitives/ProgressBar'
+import { TimeChip } from '../primitives/TimeChip'
 
 export interface KanbanCardProps {
   task: Task
@@ -54,9 +55,7 @@ export class KanbanCard {
 
     const est = task.timeEstimate ?? 0
     if (props.loggedHours > 0 || est > 0) {
-      const timeBadge = body.createEl('span', { cls: 'pm-time-chip pm-time-chip--sm' })
-      timeBadge.setText(est > 0 ? `${props.loggedHours}/${est}h` : `${props.loggedHours}h`)
-      if (est > 0 && props.loggedHours > est) timeBadge.addClass('pm-time-chip--over')
+      new TimeChip(body).setSize('sm').setHours(props.loggedHours, est)
     }
 
     if (task.tags.length) {

--- a/src/ui/primitives/IconButton.ts
+++ b/src/ui/primitives/IconButton.ts
@@ -1,0 +1,32 @@
+import { ExtraButtonComponent } from 'obsidian'
+
+export class IconButton {
+  el: HTMLElement
+  private button: ExtraButtonComponent
+
+  constructor(parentEl: HTMLElement) {
+    this.button = new ExtraButtonComponent(parentEl)
+    this.el = this.button.extraSettingsEl
+    this.el.addClass('pm-icon-btn')
+  }
+
+  setIcon(name: string): this {
+    this.button.setIcon(name)
+    return this
+  }
+
+  setTooltip(text: string): this {
+    this.button.setTooltip(text)
+    return this
+  }
+
+  setRevealOnHover(enabled: boolean): this {
+    this.el.toggleClass('pm-icon-btn--hover-only', enabled)
+    return this
+  }
+
+  onClick(handler: (e: MouseEvent) => unknown): this {
+    this.el.addEventListener('click', handler)
+    return this
+  }
+}

--- a/src/ui/primitives/TimeChip.ts
+++ b/src/ui/primitives/TimeChip.ts
@@ -1,0 +1,19 @@
+export class TimeChip {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement) {
+    this.el = parentEl.createEl('span', { cls: 'pm-time-chip' })
+  }
+
+  setHours(logged: number, estimate?: number): this {
+    const est = estimate ?? 0
+    this.el.setText(est > 0 ? `${logged}/${est}h` : `${logged}h`)
+    this.el.toggleClass('pm-time-chip--over', est > 0 && logged > est)
+    return this
+  }
+
+  setSize(size: 'md' | 'sm'): this {
+    this.el.toggleClass('pm-time-chip--sm', size === 'sm')
+    return this
+  }
+}

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -17,7 +17,9 @@ import { AvatarStack } from '../../ui/primitives/AvatarStack'
 import { Badge } from '../../ui/primitives/Badge'
 import { Chip } from '../../ui/primitives/Chip'
 import { DueDateChip } from '../../ui/primitives/DueDateChip'
+import { IconButton } from '../../ui/primitives/IconButton'
 import { ProgressBar } from '../../ui/primitives/ProgressBar'
+import { TimeChip } from '../../ui/primitives/TimeChip'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
 import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext } from './TableRenderer'
@@ -103,18 +105,15 @@ export function renderSelectCell(row: HTMLElement, task: Task, ctx: TableContext
 export function renderExpandCell(row: HTMLElement, task: Task, ctx: TableContext): void {
   const cell = row.createEl('td', { cls: 'pm-table-cell-expand' })
   if (task.subtasks.length > 0) {
-    const btn = cell.createEl('button', {
-      text: task.collapsed ? '\u25b6' : '\u25bc',
-      cls: 'pm-expand-btn',
-      attr: { 'aria-label': task.collapsed ? 'Expand subtasks' : 'Collapse subtasks' }
-    })
-    btn.addEventListener(
-      'click',
-      safeAsync(async () => {
-        await ctx.plugin.store.updateTask(ctx.project, task.id, { collapsed: !task.collapsed })
-        await ctx.onRefresh()
-      })
-    )
+    new IconButton(cell)
+      .setIcon(task.collapsed ? 'chevron-right' : 'chevron-down')
+      .setTooltip(task.collapsed ? 'Expand subtasks' : 'Collapse subtasks')
+      .onClick(
+        safeAsync(async () => {
+          await ctx.plugin.store.updateTask(ctx.project, task.id, { collapsed: !task.collapsed })
+          await ctx.onRefresh()
+        })
+      )
   }
 }
 
@@ -145,20 +144,19 @@ export function renderTitleCell(row: HTMLElement, task: Task, depth: number, ctx
     })
   })
 
-  const addSubtaskBtn = cell.createEl('button', {
-    cls: 'pm-add-subtask-btn',
-    attr: { 'aria-label': 'Add subtask', title: 'Add subtask' }
-  })
-  addSubtaskBtn.setText('+')
-  addSubtaskBtn.addEventListener('click', (e) => {
-    e.stopPropagation()
-    openTaskModal(ctx.plugin, ctx.project, {
-      parentId: task.id,
-      onSave: async () => {
-        await ctx.onRefresh()
-      }
+  new IconButton(cell)
+    .setIcon('plus')
+    .setTooltip('Add subtask')
+    .setRevealOnHover(true)
+    .onClick((e) => {
+      e.stopPropagation()
+      openTaskModal(ctx.plugin, ctx.project, {
+        parentId: task.id,
+        onSave: async () => {
+          await ctx.onRefresh()
+        }
+      })
     })
-  })
 
   if (task.type === 'milestone') {
     new Badge(cell).setLabel('M').setSize('sm').setColor('var(--color-purple)').setTooltip('Milestone')
@@ -272,24 +270,21 @@ export function renderTimeCell(row: HTMLElement, task: Task): void {
   const logged = totalLoggedHours(task)
   const est = task.timeEstimate ?? 0
   if (logged > 0 || est > 0) {
-    const chip = cell.createEl('span', { cls: 'pm-time-chip' })
-    chip.setText(est > 0 ? `${logged}/${est}h` : `${logged}h`)
-    if (est > 0 && logged > est) chip.addClass('pm-time-chip--over')
+    new TimeChip(cell).setHours(logged, est)
   }
 }
 
 export function renderActionsCell(row: HTMLElement, task: Task, ctx: TableContext): void {
   const cell = row.createEl('td', { cls: 'pm-table-cell pm-table-cell-actions' })
-  const btn = cell.createEl('button', {
-    text: '\u22ef',
-    cls: 'pm-row-menu-btn',
-    attr: { 'aria-label': 'Task actions' }
-  })
-  btn.addEventListener('click', (e) => {
-    const menu = new Menu()
-    buildTaskContextMenu(menu, task, { plugin: ctx.plugin, project: ctx.project, onRefresh: ctx.onRefresh })
-    menu.showAtMouseEvent(e)
-  })
+  new IconButton(cell)
+    .setIcon('more-horizontal')
+    .setTooltip('Task actions')
+    .setRevealOnHover(true)
+    .onClick((e) => {
+      const menu = new Menu()
+      buildTaskContextMenu(menu, task, { plugin: ctx.plugin, project: ctx.project, onRefresh: ctx.onRefresh })
+      menu.showAtMouseEvent(e)
+    })
 }
 
 export function renderCustomFieldCells(row: HTMLElement, task: Task, project: Project): void {

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -37,7 +37,9 @@ export function renderTaskRow(
   row.addEventListener('click', (e) => {
     const target = e.target as HTMLElement
     if (
-      target.closest('button, input, .pm-badge--interactive, .pm-task-title-text, .pm-due-chip, .pm-table-cell-select')
+      target.closest(
+        'button, input, .pm-badge--interactive, .pm-task-title-text, .pm-due-chip, .pm-table-cell-select, .pm-icon-btn'
+      )
     ) {
       return
     }

--- a/styles.css
+++ b/styles.css
@@ -387,18 +387,6 @@
 .pm-table-cell-actions { width: 40px; text-align: center; }
 .pm-table-cell-assignees { min-width: 80px; }
 
-.pm-expand-btn {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--pm-text-muted);
-  font-size: 11px;
-  padding: 2px 4px;
-  border-radius: 3px;
-  transition: color 0.15s;
-}
-.pm-expand-btn:hover { color: var(--pm-text); }
-
 .pm-task-title-text {
   cursor: pointer;
   font-weight: 500;
@@ -530,38 +518,13 @@
   min-width: 28px;
 }
 
-/* Row menu */
-.pm-row-menu-btn {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--pm-text-muted);
-  font-size: 16px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  line-height: 1;
+/* ── IconButton ────────────────────────────────────────────────────────── */
+.pm-icon-btn--hover-only {
   opacity: 0;
   transition: opacity 0.15s;
 }
-.pm-table-row:hover .pm-row-menu-btn { opacity: 1; }
-.pm-row-menu-btn:hover { background: var(--pm-bg3); color: var(--pm-text); }
-
-.pm-add-subtask-btn {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--pm-text-muted);
-  font-size: 14px;
-  font-weight: 600;
-  padding: 1px 5px;
-  border-radius: 4px;
-  line-height: 1;
-  opacity: 0;
-  transition: opacity 0.15s, background 0.15s, color 0.15s;
-  flex-shrink: 0;
-}
-.pm-table-row:hover .pm-add-subtask-btn { opacity: 1; }
-.pm-add-subtask-btn:hover { background: var(--pm-bg3); color: var(--pm-accent); }
+.pm-table-row:hover .pm-icon-btn--hover-only { opacity: 1; }
+.pm-icon-btn--hover-only:focus-visible { opacity: 1; }
 
 /* Tags */
 /* ── Chip ─────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Two primitives:

- `TimeChip` wraps the time-tracking chip used in tables and kanban cards. Same DOM and classes as before, no visible change.
- `IconButton` wraps `ExtraButtonComponent`. Replaces the table row expand, add-subtask, and actions buttons.

Those three table row buttons now render as lucide icons (chevron, plus, more-horizontal) via Obsidian's native button style instead of unicode glyphs.