### PR TITLE
extract simple table cells into composites

### DIFF
--- a/src/ui/composites/cells/AssigneesCell.ts
+++ b/src/ui/composites/cells/AssigneesCell.ts
@@ -1,0 +1,10 @@
+import { AvatarStack } from '../../primitives/AvatarStack'
+
+export class AssigneesCell {
+  el: HTMLTableCellElement
+
+  constructor(parentRow: HTMLElement, assignees: string[]) {
+    this.el = parentRow.createEl('td', { cls: 'pm-table-cell pm-table-cell-assignees' })
+    new AvatarStack(this.el).setNames(assignees).setMax(3)
+  }
+}

--- a/src/ui/composites/cells/CustomFieldCell.ts
+++ b/src/ui/composites/cells/CustomFieldCell.ts
@@ -1,0 +1,8 @@
+export class CustomFieldCell {
+  el: HTMLTableCellElement
+
+  constructor(parentRow: HTMLElement, display: string) {
+    this.el = parentRow.createEl('td', { cls: 'pm-table-cell' })
+    this.el.createEl('span', { text: display || '—', cls: 'pm-cf-value' })
+  }
+}

--- a/src/ui/composites/cells/ProgressCell.ts
+++ b/src/ui/composites/cells/ProgressCell.ts
@@ -1,0 +1,15 @@
+import { ProgressBar } from '../../primitives/ProgressBar'
+
+export interface ProgressCellProps {
+  value: number
+  color: string
+}
+
+export class ProgressCell {
+  el: HTMLTableCellElement
+
+  constructor(parentRow: HTMLElement, props: ProgressCellProps) {
+    this.el = parentRow.createEl('td', { cls: 'pm-table-cell pm-table-cell-progress' })
+    new ProgressBar(this.el).setValue(props.value).setColor(props.color).setShowLabel(true)
+  }
+}

--- a/src/ui/composites/cells/TimeCell.ts
+++ b/src/ui/composites/cells/TimeCell.ts
@@ -1,0 +1,17 @@
+import { TimeChip } from '../../primitives/TimeChip'
+
+export interface TimeCellProps {
+  logged: number
+  estimate: number
+}
+
+export class TimeCell {
+  el: HTMLTableCellElement
+
+  constructor(parentRow: HTMLElement, props: TimeCellProps) {
+    this.el = parentRow.createEl('td', { cls: 'pm-table-cell pm-table-cell-time' })
+    if (props.logged > 0 || props.estimate > 0) {
+      new TimeChip(this.el).setHours(props.logged, props.estimate)
+    }
+  }
+}

--- a/src/views/table/TableCellRenderers.ts
+++ b/src/views/table/TableCellRenderers.ts
@@ -1,25 +1,13 @@
 import { Menu } from 'obsidian'
-import type { Task, Project } from '../../types'
-import { totalLoggedHours } from '../../store/TaskTreeOps'
-import {
-  formatDateLong,
-  isTaskOverdue,
-  getStatusConfig,
-  getPriorityConfig,
-  safeAsync,
-  stringifyCustomValue
-} from '../../utils'
+import type { Task } from '../../types'
+import { formatDateLong, isTaskOverdue, getStatusConfig, getPriorityConfig, safeAsync } from '../../utils'
 import { today, parsePlainDate } from '../../dates'
-import { COLOR_ACCENT } from '../../constants'
 import { renderStatusBadge, renderPriorityBadge } from '../../ui/StatusBadge'
 import { openTaskModal } from '../../ui/ModalFactory'
-import { AvatarStack } from '../../ui/primitives/AvatarStack'
 import { Badge } from '../../ui/primitives/Badge'
 import { Chip } from '../../ui/primitives/Chip'
 import { DueDateChip } from '../../ui/primitives/DueDateChip'
 import { IconButton } from '../../ui/primitives/IconButton'
-import { ProgressBar } from '../../ui/primitives/ProgressBar'
-import { TimeChip } from '../../ui/primitives/TimeChip'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
 import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext } from './TableRenderer'
@@ -211,11 +199,6 @@ export function renderPriorityCell(row: HTMLElement, task: Task, ctx: TableConte
   }
 }
 
-export function renderAssigneesCell(row: HTMLElement, task: Task): void {
-  const cell = row.createEl('td', { cls: 'pm-table-cell pm-table-cell-assignees' })
-  new AvatarStack(cell).setNames(task.assignees).setMax(3)
-}
-
 function startDueDateEdit(cell: HTMLElement, display: HTMLElement, task: Task, ctx: TableContext): void {
   makeInlineEdit({
     container: cell,
@@ -257,23 +240,6 @@ export function renderDueDateCell(row: HTMLElement, task: Task, ctx: TableContex
     })
 }
 
-export function renderProgressCell(row: HTMLElement, task: Task, statusColor: string | undefined): void {
-  const cell = row.createEl('td', { cls: 'pm-table-cell pm-table-cell-progress' })
-  new ProgressBar(cell)
-    .setValue(task.progress)
-    .setColor(statusColor ?? COLOR_ACCENT)
-    .setShowLabel(true)
-}
-
-export function renderTimeCell(row: HTMLElement, task: Task): void {
-  const cell = row.createEl('td', { cls: 'pm-table-cell pm-table-cell-time' })
-  const logged = totalLoggedHours(task)
-  const est = task.timeEstimate ?? 0
-  if (logged > 0 || est > 0) {
-    new TimeChip(cell).setHours(logged, est)
-  }
-}
-
 export function renderActionsCell(row: HTMLElement, task: Task, ctx: TableContext): void {
   const cell = row.createEl('td', { cls: 'pm-table-cell pm-table-cell-actions' })
   new IconButton(cell)
@@ -285,13 +251,4 @@ export function renderActionsCell(row: HTMLElement, task: Task, ctx: TableContex
       buildTaskContextMenu(menu, task, { plugin: ctx.plugin, project: ctx.project, onRefresh: ctx.onRefresh })
       menu.showAtMouseEvent(e)
     })
-}
-
-export function renderCustomFieldCells(row: HTMLElement, task: Task, project: Project): void {
-  for (const cf of project.customFields) {
-    const cell = row.createEl('td', { cls: 'pm-table-cell' })
-    const val = task.customFields[cf.id]
-    const display = val !== undefined ? stringifyCustomValue(val) : ''
-    cell.createEl('span', { text: display || '\u2014', cls: 'pm-cf-value' })
-  }
 }

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -1,4 +1,6 @@
-import { getStatusConfig, isTerminalStatus } from '../../utils'
+import { getStatusConfig, isTerminalStatus, stringifyCustomValue } from '../../utils'
+import { totalLoggedHours } from '../../store/TaskTreeOps'
+import { COLOR_ACCENT } from '../../constants'
 import type { Task } from '../../types'
 import type { TableContext, TableState } from './TableRenderer'
 import {
@@ -7,13 +9,13 @@ import {
   renderTitleCell,
   renderStatusCell,
   renderPriorityCell,
-  renderAssigneesCell,
   renderDueDateCell,
-  renderProgressCell,
-  renderTimeCell,
-  renderCustomFieldCells,
   renderActionsCell
 } from './TableCellRenderers'
+import { AssigneesCell } from '../../ui/composites/cells/AssigneesCell'
+import { CustomFieldCell } from '../../ui/composites/cells/CustomFieldCell'
+import { ProgressCell } from '../../ui/composites/cells/ProgressCell'
+import { TimeCell } from '../../ui/composites/cells/TimeCell'
 
 // ─── Row orchestrator ──────────────────────────────────────────────────────────
 
@@ -52,11 +54,14 @@ export function renderTaskRow(
   renderTitleCell(row, task, depth, ctx)
   renderStatusCell(row, task, ctx)
   renderPriorityCell(row, task, ctx)
-  renderAssigneesCell(row, task)
+  new AssigneesCell(row, task.assignees)
   renderDueDateCell(row, task, ctx)
-  renderProgressCell(row, task, statusConfig?.color)
-  renderTimeCell(row, task)
-  renderCustomFieldCells(row, task, ctx.project)
+  new ProgressCell(row, { value: task.progress, color: statusConfig?.color ?? COLOR_ACCENT })
+  new TimeCell(row, { logged: totalLoggedHours(task), estimate: task.timeEstimate ?? 0 })
+  for (const cf of ctx.project.customFields) {
+    const val = task.customFields[cf.id]
+    new CustomFieldCell(row, val !== undefined ? stringifyCustomValue(val) : '')
+  }
   renderActionsCell(row, task, ctx)
 }
 


### PR DESCRIPTION
Pulls four trivial cells out of `TableCellRenderers.ts` into `src/ui/composites/cells/`: `AssigneesCell`, `ProgressCell`, `TimeCell`, `CustomFieldCell`. `TableRow` instantiates them directly and computes the resolved values (logged hours, custom-field display string).

Internal refactor. No visual or behavior changes.