### PR TITLE
extract TaskRow composite for row scaffolding

### DIFF
--- a/src/ui/composites/TaskRow.ts
+++ b/src/ui/composites/TaskRow.ts
@@ -1,0 +1,30 @@
+const ROW_IGNORE_SELECTOR =
+  'button, input, .pm-badge--interactive, .pm-task-title-text, .pm-due-chip, .pm-table-cell-select, .pm-icon-btn'
+
+export interface TaskRowProps {
+  taskId: string
+  depth: number
+  isDone: boolean
+  isArchived: boolean
+  isSelected: boolean
+  onRowClick: () => void
+}
+
+export class TaskRow {
+  el: HTMLTableRowElement
+
+  constructor(tbody: HTMLElement, props: TaskRowProps) {
+    this.el = tbody.createEl('tr', { cls: 'pm-table-row' })
+    this.el.dataset.taskId = props.taskId
+    if (props.isDone) this.el.addClass('pm-table-row--done')
+    if (props.isArchived) this.el.addClass('pm-table-row--archived')
+    if (props.isSelected) this.el.addClass('pm-table-row--selected')
+    this.el.style.setProperty('--depth', String(props.depth))
+
+    this.el.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement
+      if (target.closest(ROW_IGNORE_SELECTOR)) return
+      props.onRowClick()
+    })
+  }
+}

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -8,6 +8,7 @@ import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext, TableState } from './TableRenderer'
 import { openTaskModal } from '../../ui/ModalFactory'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
+import { TaskRow } from '../../ui/composites/TaskRow'
 import { ActionsCell } from '../../ui/composites/cells/ActionsCell'
 import { AssigneesCell } from '../../ui/composites/cells/AssigneesCell'
 import { CustomFieldCell } from '../../ui/composites/cells/CustomFieldCell'
@@ -32,24 +33,16 @@ export function renderTaskRow(
   const isDone = isTerminalStatus(task.status, ctx.plugin.settings.statuses)
   const statusConfig = getStatusConfig(ctx.plugin.settings.statuses, task.status)
 
-  const row = tbody.createEl('tr', { cls: 'pm-table-row' })
-  row.dataset.taskId = task.id
-  if (isDone) row.addClass('pm-table-row--done')
-  if (task.archived) row.addClass('pm-table-row--archived')
-  if (ctx.state.selectedTaskId === task.id) row.addClass('pm-table-row--selected')
-  row.style.setProperty('--depth', String(depth))
-
-  row.addEventListener('click', (e) => {
-    const target = e.target as HTMLElement
-    if (
-      target.closest(
-        'button, input, .pm-badge--interactive, .pm-task-title-text, .pm-due-chip, .pm-table-cell-select, .pm-icon-btn'
-      )
-    ) {
-      return
+  const { el: row } = new TaskRow(tbody, {
+    taskId: task.id,
+    depth,
+    isDone,
+    isArchived: !!task.archived,
+    isSelected: ctx.state.selectedTaskId === task.id,
+    onRowClick: () => {
+      ctx.state.selectedTaskId = task.id
+      updateSelectedRow(ctx.state)
     }
-    ctx.state.selectedTaskId = task.id
-    updateSelectedRow(ctx.state)
   })
 
   new SelectCell(row, {


### PR DESCRIPTION
Pulls the `<tr>` creation, row classes (`done` / `archived` / `selected`), `--depth` CSS var, and the row-click handler out of `TableRow.ts` into a presentational `TaskRow` composite at `src/ui/composites/`. The composite imports nothing from `../store/` or `../main`; `TableRow.ts` stays as the orchestrator that builds props and wires the cells.

Internal refactor. No visual or behavior changes.