### PR TITLE
add ViewSwitcher and SegmentedControl primitives

### DIFF
--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -5,6 +5,7 @@ import { flattenTasks } from '../store/TaskTreeOps'
 import { wouldCreateCycle } from '../store/Scheduler'
 import { renderPropRow, renderProgressSlider, renderChipList } from '../ui/FormField'
 import { Badge } from '../ui/primitives/Badge'
+import { SegmentedControl } from '../ui/primitives/SegmentedControl'
 import { COLOR_MUTED } from '../constants'
 import { getStatusConfig, getPriorityConfig, formatBadgeText } from '../utils'
 import { renderCustomFieldInput } from './CustomFieldInputs'
@@ -78,29 +79,26 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
 
   // Type
   renderPropRow(container, 'Type', () => {
-    const wrap = createDiv('pm-prop-value pm-prop-type-selector')
-    const types: { id: TaskType; label: string; cls: string }[] = [
-      { id: 'task', label: 'Task', cls: '' },
-      { id: 'subtask', label: 'Subtask', cls: 'pm-prop-type-btn--subtask' },
-      { id: 'milestone', label: 'Milestone', cls: 'pm-prop-type-btn--milestone' }
-    ]
-    for (const t of types) {
-      const btn = wrap.createEl('button', {
-        cls: `pm-prop-type-btn ${t.cls} ${task.type === t.id ? 'pm-prop-type-btn--active' : ''}`
-      })
-      btn.setText(t.label)
-      btn.addEventListener('click', () => {
-        task.type = t.id
-        if (t.id === 'milestone') {
+    const wrap = createDiv('pm-prop-value')
+    new SegmentedControl<TaskType>(wrap, {
+      options: [
+        { id: 'task', label: 'Task' },
+        { id: 'subtask', label: 'Subtask', cls: 'pm-segmented-btn--subtask' },
+        { id: 'milestone', label: 'Milestone', cls: 'pm-segmented-btn--milestone' }
+      ],
+      active: task.type,
+      onChange: (type) => {
+        task.type = type
+        if (type === 'milestone') {
           task.start = ''
           task.progress = 0
         }
-        if (t.id !== 'subtask') {
+        if (type !== 'subtask') {
           ctx.setParentId(null)
         }
         rerender()
-      })
-    }
+      }
+    })
     return wrap
   })
 

--- a/src/ui/primitives/SegmentedControl.ts
+++ b/src/ui/primitives/SegmentedControl.ts
@@ -1,0 +1,29 @@
+export interface SegmentedOption<T extends string> {
+  id: T
+  label: string
+  cls?: string
+}
+
+export interface SegmentedControlProps<T extends string> {
+  options: SegmentedOption<T>[]
+  active: T
+  onChange: (id: T) => void
+}
+
+export class SegmentedControl<T extends string> {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement, props: SegmentedControlProps<T>) {
+    this.el = parentEl.createDiv('pm-segmented')
+    for (const opt of props.options) {
+      const btn = this.el.createEl('button', { cls: 'pm-segmented-btn', text: opt.label })
+      if (opt.cls) btn.addClass(opt.cls)
+      if (opt.id === props.active) btn.addClass('pm-segmented-btn--active')
+      btn.addEventListener('click', () => {
+        this.el.querySelectorAll('.pm-segmented-btn').forEach((b) => b.removeClass('pm-segmented-btn--active'))
+        btn.addClass('pm-segmented-btn--active')
+        props.onChange(opt.id)
+      })
+    }
+  }
+}

--- a/src/ui/primitives/ViewSwitcher.ts
+++ b/src/ui/primitives/ViewSwitcher.ts
@@ -1,0 +1,33 @@
+export interface ViewSwitcherOption<T extends string> {
+  id: T
+  icon: string
+  label: string
+}
+
+export interface ViewSwitcherProps<T extends string> {
+  options: ViewSwitcherOption<T>[]
+  active: T
+  onChange: (id: T) => void
+}
+
+export class ViewSwitcher<T extends string> {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement, props: ViewSwitcherProps<T>) {
+    this.el = parentEl.createDiv('pm-view-switcher')
+    for (const opt of props.options) {
+      const btn = this.el.createEl('button', {
+        cls: 'pm-view-btn',
+        attr: { 'aria-label': `Switch to ${opt.label} view` }
+      })
+      btn.createEl('span', { text: opt.icon, cls: 'pm-view-btn-icon' })
+      btn.createEl('span', { text: opt.label })
+      if (opt.id === props.active) btn.addClass('pm-view-btn--active')
+      btn.addEventListener('click', () => {
+        this.el.querySelectorAll('.pm-view-btn').forEach((b) => b.removeClass('pm-view-btn--active'))
+        btn.addClass('pm-view-btn--active')
+        props.onChange(opt.id)
+      })
+    }
+  }
+}

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -8,6 +8,7 @@ import type { TableViewState } from './table/TableView'
 import { GanttView } from './gantt/GanttView'
 import { KanbanView } from './KanbanView'
 import { openProjectModal, openTaskModal } from '../ui/ModalFactory'
+import { ViewSwitcher } from '../ui/primitives/ViewSwitcher'
 
 export const PM_PROJECT_VIEW_TYPE = 'pm-project'
 
@@ -176,27 +177,18 @@ export class ProjectView extends ItemView {
       })
     )
 
-    const switcher = this.toolbarEl.createDiv('pm-view-switcher')
-    const views: { mode: ViewMode; icon: string; label: string }[] = [
-      { mode: 'table', icon: '≡', label: 'Table' },
-      { mode: 'gantt', icon: '▬', label: 'Gantt' },
-      { mode: 'kanban', icon: '⊞', label: 'Board' }
-    ]
-    for (const v of views) {
-      const btn = switcher.createEl('button', {
-        cls: 'pm-view-btn',
-        attr: { 'aria-label': `Switch to ${v.label} view` }
-      })
-      btn.createEl('span', { text: v.icon, cls: 'pm-view-btn-icon' })
-      btn.createEl('span', { text: v.label })
-      if (v.mode === this.currentView) btn.addClass('pm-view-btn--active')
-      btn.addEventListener('click', () => {
-        this.currentView = v.mode
-        switcher.querySelectorAll('.pm-view-btn').forEach((b) => b.removeClass('pm-view-btn--active'))
-        btn.addClass('pm-view-btn--active')
+    new ViewSwitcher<ViewMode>(this.toolbarEl, {
+      options: [
+        { id: 'table', icon: '≡', label: 'Table' },
+        { id: 'gantt', icon: '▬', label: 'Gantt' },
+        { id: 'kanban', icon: '⊞', label: 'Board' }
+      ],
+      active: this.currentView,
+      onChange: (mode) => {
+        this.currentView = mode
         this.renderCurrentView()
-      })
-    }
+      }
+    })
 
     const right = this.toolbarEl.createDiv('pm-toolbar-right')
     new ButtonComponent(right)

--- a/styles.css
+++ b/styles.css
@@ -1410,8 +1410,9 @@
    NEW: Milestone, Time Tracking, Recurrence, Drag Handles, Inline Edit
    ═══════════════════════════════════════════════════════════════════════════ */
 
-/* ── Task type toggle ──────────────────────────────────────────────────── */
-.pm-prop-type-btn {
+/* ── SegmentedControl ──────────────────────────────────────────────────── */
+.pm-segmented { display: flex; gap: 6px; }
+.pm-segmented-btn {
   all: unset;
   cursor: pointer;
   padding: 4px 12px;
@@ -1422,21 +1423,20 @@
   border: 1px solid var(--pm-border);
   transition: all 0.15s;
 }
-.pm-prop-type-btn:hover { background: var(--pm-bg3); }
-.pm-prop-type-btn--milestone {
+.pm-segmented-btn:hover { background: var(--pm-bg3); }
+.pm-segmented-btn--milestone {
   background: rgba(139,114,190,0.15);
   border-color: rgba(139,114,190,0.4);
   color: #69519a;
 }
-.pm-prop-type-btn--subtask {
+.pm-segmented-btn--subtask {
   background: rgba(121,181,141,0.15);
   border-color: rgba(121,181,141,0.4);
   color: #79b58d;
 }
-.pm-prop-type-btn--active {
+.pm-segmented-btn--active {
   box-shadow: 0 0 0 2px var(--pm-accent);
 }
-.pm-prop-type-selector { gap: 6px; }
 
 /* ── Recurrence picker ─────────────────────────────────────────────────── */
 .pm-prop-recurrence { flex-wrap: wrap; gap: 6px; }


### PR DESCRIPTION
Two generic typed primitives:

- `ViewSwitcher<T>` replaces the `pm-view-switcher` markup in `ProjectView` (Table / Gantt / Board tabs).
- `SegmentedControl<T>` replaces the `pm-prop-type-*` markup in the task modal type selector (Task / Subtask / Milestone).

`pm-prop-type-*` CSS rules renamed to `pm-segmented-*` to match. The selector wrap is now `.pm-prop-value > .pm-segmented`, which adds one DOM level but keeps the same flex + gap layout, so visuals are unchanged.