### PR TITLE
paste and drop attachments in task modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Paste a screenshot or drag any file onto the task modal description to save it under the vault's attachments folder and embed it as `![[...]]` at the cursor
 - Search box, filters (status, priority, assignee, tag, due date, archived), and saved views now appear above every view, not just the table
 - Filter state persists per project across plugin reloads
 - Saved views remember the view mode they were created in; selecting one switches the project to that mode

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -234,7 +234,7 @@ export class TaskModal extends Modal {
           const file = item.getAsFile()
           if (file) {
             const stamp = new Date().toISOString().replace(/[:.]/g, '-')
-            const sub = item.type.split('/')[1] || 'png'
+            const sub = (item.type.split('/')[1] || 'png').split('+')[0]
             const ext = sub === 'jpeg' ? 'jpg' : sub
             attachments.push({ blob: file, name: `Pasted-${stamp}.${ext}` })
           }

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -72,19 +72,15 @@ export class TaskModal extends Modal {
     return this.persistPromise
   }
 
-  private async insertPastedImages(
+  private async insertAttachments(
     descArea: HTMLTextAreaElement,
-    images: { blob: Blob; mime: string }[],
+    items: { blob: Blob; name: string }[],
     sourcePath: string,
     autoResize: () => void
   ): Promise<void> {
-    for (const { blob, mime } of images) {
-      const stamp = new Date().toISOString().replace(/[:.]/g, '-')
-      const sub = mime.split('/')[1] || 'png'
-      const ext = sub === 'jpeg' ? 'jpg' : sub
-      const baseName = `Pasted-${stamp}.${ext}`
+    for (const { blob, name } of items) {
       try {
-        const path = await this.app.fileManager.getAvailablePathForAttachment(baseName, sourcePath)
+        const path = await this.app.fileManager.getAvailablePathForAttachment(name, sourcePath)
         const buffer = await blob.arrayBuffer()
         const file = await this.app.vault.createBinary(path, buffer)
         const snippet = `![[${file.name}]]`
@@ -92,8 +88,8 @@ export class TaskModal extends Modal {
         this.task.description = descArea.value
         autoResize()
       } catch (err) {
-        console.error('Failed to save pasted image', err)
-        new Notice('Failed to save pasted image')
+        console.error('Failed to save attachment', err)
+        new Notice('Failed to save attachment')
       }
     }
   }
@@ -232,16 +228,39 @@ export class TaskModal extends Modal {
     descArea.addEventListener('paste', (e) => {
       const items = e.clipboardData?.items
       if (!items) return
-      const images: { blob: Blob; mime: string }[] = []
+      const attachments: { blob: Blob; name: string }[] = []
       for (const item of items) {
         if (item.kind === 'file' && item.type.startsWith('image/')) {
           const file = item.getAsFile()
-          if (file) images.push({ blob: file, mime: item.type })
+          if (file) {
+            const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+            const sub = item.type.split('/')[1] || 'png'
+            const ext = sub === 'jpeg' ? 'jpg' : sub
+            attachments.push({ blob: file, name: `Pasted-${stamp}.${ext}` })
+          }
         }
       }
-      if (images.length === 0) return
+      if (attachments.length === 0) return
       e.preventDefault()
-      void this.insertPastedImages(descArea, images, sourcePath, autoResize)
+      void this.insertAttachments(descArea, attachments, sourcePath, autoResize)
+    })
+
+    descSection.addEventListener('dragover', (e) => {
+      if (!e.dataTransfer) return
+      if (!Array.from(e.dataTransfer.types).includes('Files')) return
+      e.preventDefault()
+    })
+
+    descSection.addEventListener('drop', (e) => {
+      const files = e.dataTransfer?.files
+      if (!files || files.length === 0) return
+      e.preventDefault()
+      if (descArea.classList.contains('pm-hidden')) {
+        showEdit()
+        descArea.selectionStart = descArea.selectionEnd = descArea.value.length
+      }
+      const attachments = Array.from(files).map((f) => ({ blob: f, name: f.name }))
+      void this.insertAttachments(descArea, attachments, sourcePath, autoResize)
     })
 
     // Note link suggest (inline [[ autocomplete)

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -72,6 +72,32 @@ export class TaskModal extends Modal {
     return this.persistPromise
   }
 
+  private async insertPastedImages(
+    descArea: HTMLTextAreaElement,
+    images: { blob: Blob; mime: string }[],
+    sourcePath: string,
+    autoResize: () => void
+  ): Promise<void> {
+    for (const { blob, mime } of images) {
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+      const sub = mime.split('/')[1] || 'png'
+      const ext = sub === 'jpeg' ? 'jpg' : sub
+      const baseName = `Pasted-${stamp}.${ext}`
+      try {
+        const path = await this.app.fileManager.getAvailablePathForAttachment(baseName, sourcePath)
+        const buffer = await blob.arrayBuffer()
+        const file = await this.app.vault.createBinary(path, buffer)
+        const snippet = `![[${file.name}]]`
+        descArea.setRangeText(snippet, descArea.selectionStart, descArea.selectionEnd, 'end')
+        this.task.description = descArea.value
+        autoResize()
+      } catch (err) {
+        console.error('Failed to save pasted image', err)
+        new Notice('Failed to save pasted image')
+      }
+    }
+  }
+
   private async runPersist(): Promise<void> {
     if (this.isNew) {
       await this.plugin.store.insertTask(this.project, this.task, this.parentId)
@@ -202,6 +228,21 @@ export class TaskModal extends Modal {
       autoResize()
     })
     descArea.addEventListener('blur', () => showPreview())
+
+    descArea.addEventListener('paste', (e) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      const images: { blob: Blob; mime: string }[] = []
+      for (const item of items) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          const file = item.getAsFile()
+          if (file) images.push({ blob: file, mime: item.type })
+        }
+      }
+      if (images.length === 0) return
+      e.preventDefault()
+      void this.insertPastedImages(descArea, images, sourcePath, autoResize)
+    })
 
     // Note link suggest (inline [[ autocomplete)
     this.noteSuggest?.destroy()


### PR DESCRIPTION
## Summary
- Cmd/Ctrl+V on an image in the task description saves it under the vault's attachments folder and embeds it as `![[Pasted-<timestamp>.<ext>]]` at the cursor
- Dragging any file (image, PDF, etc.) onto the description area does the same, preserving the original filename
- Both paths share `insertAttachments`, which routes through `app.fileManager.getAvailablePathForAttachment` + `vault.createBinary` so the user's attachments-folder setting is respected
- Drop while in preview mode auto-switches to edit and appends at end so existing content isn't overwritten

## Test plan
- [ ] Cmd/Ctrl+V with an image on the clipboard inserts `![[Pasted-...]]` and renders in preview after blur
- [ ] Plain-text paste is unaffected
- [ ] Multiple images in one paste are inserted in order
- [ ] Drag a PNG from Finder onto the description — file saved, embed inserted, preview renders
- [ ] Drag a PDF — file saved, `![[file.pdf]]` inserted (Obsidian renders PDFs inline)
- [ ] Drop while in preview mode — switches to edit, appends at end
- [ ] `pnpm check && pnpm check:submission && pnpm test` all green