### PR TITLE
use native obsidian icons for expand and add-subtask in table

### DIFF
--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -74,7 +74,7 @@ export class ProjectModal extends Modal {
 
     // Icon picker
     const iconWrap = topRow.createDiv('pm-icon-picker')
-    const iconBtn = iconWrap.createEl('button', { text: this.project.icon, cls: 'pm-icon-btn' })
+    const iconBtn = iconWrap.createEl('button', { text: this.project.icon, cls: 'pm-icon-picker-btn' })
 
     const iconGrid = iconWrap.createDiv('pm-icon-grid')
     iconGrid.addClass('pm-hidden')

--- a/src/ui/composites/cells/ExpandCell.ts
+++ b/src/ui/composites/cells/ExpandCell.ts
@@ -1,4 +1,4 @@
-import { IconButton } from '../../primitives/IconButton'
+import { setIcon } from 'obsidian'
 
 export interface ExpandCellProps {
   hasSubtasks: boolean
@@ -12,10 +12,11 @@ export class ExpandCell {
   constructor(parentRow: HTMLElement, props: ExpandCellProps) {
     this.el = parentRow.createEl('td', { cls: 'pm-table-cell-expand' })
     if (props.hasSubtasks) {
-      new IconButton(this.el)
-        .setIcon(props.collapsed ? 'chevron-right' : 'chevron-down')
-        .setTooltip(props.collapsed ? 'Expand subtasks' : 'Collapse subtasks')
-        .onClick(props.onToggle)
+      const toggle = this.el.createDiv({ cls: 'tree-item-icon collapse-icon' })
+      setIcon(toggle, 'right-triangle')
+      toggle.toggleClass('is-collapsed', props.collapsed)
+      toggle.setAttr('aria-label', props.collapsed ? 'Expand subtasks' : 'Collapse subtasks')
+      toggle.addEventListener('click', props.onToggle)
     }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -372,6 +372,15 @@
   pointer-events: auto;
 }
 .pm-table-cell-expand { width: 32px; text-align: center; padding: 0; }
+.pm-table-cell-expand .collapse-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+.pm-table-cell-expand .collapse-icon:hover { color: var(--text-normal); }
+.pm-table-cell-expand .collapse-icon.is-collapsed .svg-icon { transform: rotate(-90deg); }
 .pm-table-cell-progress { min-width: 120px; }
 .pm-table-cell-actions { width: 40px; text-align: center; }
 .pm-table-cell-assignees { min-width: 80px; }
@@ -1223,7 +1232,7 @@
 
 /* Icon picker */
 .pm-icon-picker { position: relative; flex-shrink: 0; }
-.pm-icon-btn {
+.pm-icon-picker-btn {
   font-size: 32px;
   background: var(--pm-bg2);
   border: 1px solid var(--pm-border);
@@ -1233,7 +1242,7 @@
   transition: background 0.15s;
   line-height: 1;
 }
-.pm-icon-btn:hover { background: var(--pm-bg3); }
+.pm-icon-picker-btn:hover { background: var(--pm-bg3); }
 .pm-icon-grid {
   position: absolute;
   top: calc(100% + 4px);


### PR DESCRIPTION
Table expand/collapse now uses obsidian's right-triangle pattern from the file tree.

The IconButton primitive's class also clashed with the project icon-picker, so the `+` and `...` icons in rows were inheriting the picker's chunky bordered button look. Renamed the picker class.