### PR TITLE
drop id suffix from new task filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gantt milestone labels and dependency arrows now respect the active filter
 - View switcher buttons are icon-only (previously icon + label)
 - Assignee avatar initials combine the first letter of the first two words (e.g., "Michael Jordan" becomes "MJ" instead of "MI"), so people who share a first name don't collide as often
+- New task files save as `<slug>.md` instead of `<slug>-<id>.md`. Existing files keep their current name until the title changes or you rename them yourself
 
 ### Removed
 

--- a/src/modals/ImportModal.ts
+++ b/src/modals/ImportModal.ts
@@ -344,7 +344,7 @@ export class ImportModal extends Modal {
           })
 
           // Generate file path for task
-          const newFilePath = taskFilePath(task.title, task.id, tasksFolder)
+          const newFilePath = taskFilePath(task.title, tasksFolder)
 
           // Serialize task to file content
           const newContent = serializeTask(task, this.project, null)

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -18,6 +18,23 @@ import { serializeProject, serializeTask, taskFilePath } from './YamlSerializer'
 import { ensureFolder } from './vaultFs'
 
 /**
+ * Pick a save path for a task. New tasks get the bare-slug name from
+ * `taskFilePath`. Legacy `<slug>-<id8>.md` files are kept in place as long
+ * as their slug still matches the current title, so untouched vaults don't
+ * churn just because the suffix scheme changed.
+ */
+function resolveTaskPath(task: Task, folder: string, previousPath: string | undefined): string {
+  const desired = taskFilePath(task.title, folder)
+  if (!previousPath) return desired
+  const desiredBasename = desired.slice(desired.lastIndexOf('/') + 1).replace(/\.md$/, '')
+  const previousFolder = previousPath.slice(0, previousPath.lastIndexOf('/'))
+  const previousBasename = previousPath.slice(previousPath.lastIndexOf('/') + 1).replace(/\.md$/, '')
+  const legacyBasename = `${desiredBasename}-${task.id.slice(0, 8)}`
+  if (previousFolder === folder && previousBasename === legacyBasename) return previousPath
+  return desired
+}
+
+/**
  * Handles all read/write operations against the Obsidian vault.
  *
  * Storage layout:
@@ -244,8 +261,9 @@ export class ProjectStore {
   }
 
   private async saveTaskFile(task: Task, project: Project, parentTask: Task | null, folder: string): Promise<void> {
-    const filePath = normalizePath(taskFilePath(task.title, task.id, folder))
-    const oldFilePath = task.filePath && task.filePath !== filePath ? task.filePath : null
+    const previousPath = task.filePath
+    const filePath = normalizePath(resolveTaskPath(task, folder, previousPath))
+    const oldFilePath = previousPath && previousPath !== filePath ? previousPath : null
     task.filePath = filePath
 
     try {
@@ -253,6 +271,9 @@ export class ProjectStore {
       const content = serializeTask(task, project, parentTask, this.getStatuses())
       const existing = this.app.vault.getAbstractFileByPath(filePath)
       if (existing instanceof TFile) {
+        if (existing.path !== previousPath) {
+          throw new Error(`Another file already exists at "${filePath}". Rename one task to resolve.`)
+        }
         await this.app.vault.modify(existing, content)
       } else {
         await this.app.vault.create(filePath, content)

--- a/src/store/YamlSerializer.ts
+++ b/src/store/YamlSerializer.ts
@@ -108,8 +108,7 @@ export function serializeTask(
     yamlLines.push('')
     yamlLines.push('## Subtasks')
     for (const sub of task.subtasks) {
-      const subSlug = sanitizeFileName(sub.title).toLowerCase().replace(/\s+/g, '-').slice(0, 40)
-      const subBasename = `${subSlug}-${sub.id.slice(0, 8)}`
+      const subBasename = sub.filePath ? sub.filePath.replace(/^.*\//, '').replace(/\.md$/, '') : taskSlug(sub.title)
       const check = isTerminalStatus(sub.status, statuses) ? 'x' : ' '
       yamlLines.push(`- [${check}] [[${subBasename}|${sub.title}]]`)
     }
@@ -118,8 +117,11 @@ export function serializeTask(
   return yamlLines.join('\n')
 }
 
+function taskSlug(title: string): string {
+  return sanitizeFileName(title).toLowerCase().replace(/\s+/g, '-').slice(0, 40)
+}
+
 /** Build the file path for a task .md file */
-export function taskFilePath(taskTitle: string, taskId: string, folder: string): string {
-  const slug = sanitizeFileName(taskTitle).toLowerCase().replace(/\s+/g, '-').slice(0, 40)
-  return `${folder}/${slug}-${taskId.slice(0, 8)}.md`
+export function taskFilePath(taskTitle: string, folder: string): string {
+  return `${folder}/${taskSlug(taskTitle)}.md`
 }

--- a/src/store/yaml-round-trip.test.ts
+++ b/src/store/yaml-round-trip.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { hydrateProjectFromFrontmatter, hydrateTaskFromFile } from './YamlHydrator'
 import { parseFrontmatter } from './YamlParser'
-import { serializeProject, serializeTask } from './YamlSerializer'
+import { serializeProject, serializeTask, taskFilePath } from './YamlSerializer'
 import { makeProject, makeTask, type Project, type SavedView, type Task } from '../types'
 
 function roundTripTask(
@@ -104,6 +104,16 @@ describe('task round-trip', () => {
     expect(task.customFields).toEqual({ impact: 'high', score: 42 })
   })
 
+  it('subtask wikilinks derive from sub.filePath, falling back to a bare slug', () => {
+    const project = makeProject('P', 'Projects/P.md')
+    const legacySub = makeTask({ id: 'sub-legacy', title: 'Legacy', filePath: 'Projects/P_tasks/legacy-12345678.md' })
+    const newSub = makeTask({ id: 'sub-new', title: 'Fresh One' }) // no filePath yet
+    const parent = makeTask({ id: 'parent', subtasks: [legacySub, newSub] })
+    const md = serializeTask(parent, project, null)
+    expect(md).toContain('[[legacy-12345678|Legacy]]')
+    expect(md).toContain('[[fresh-one|Fresh One]]')
+  })
+
   it('drops auto-generated Parent wiki-link and Subtasks section from the description', () => {
     const child = makeTask({ id: 'child' })
     const parent = makeTask({ id: 'parent-x', description: 'User-written note.', subtasks: [child] })
@@ -180,6 +190,11 @@ describe('project round-trip', () => {
     expect(frontmatter.taskIds).toEqual(['t-dup'])
     const bulletCount = md.split('\n').filter((l) => l.startsWith('- [ ] [[dup-tdup|')).length
     expect(bulletCount).toBe(1)
+  })
+
+  it('taskFilePath returns a bare-slug path without an id suffix', () => {
+    expect(taskFilePath('Bug Fix', 'Projects/P_tasks')).toBe('Projects/P_tasks/bug-fix.md')
+    expect(taskFilePath('A/B:C', 'Projects/P_tasks')).toBe('Projects/P_tasks/a-b-c.md')
   })
 
   it('falls back to the file basename when title is missing', () => {


### PR DESCRIPTION
New task files now save as `<slug>.md` instead of `<slug>-<id>.md`. Existing files stay put until the title changes or you rename them yourself.