### PR TITLE
show task filename collision inline instead of as a toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duplicate task entries when creating a task
 - Saved-view pill staying highlighted after the user diverged from its filter
 - Garbled avatar initials when an assignee was stored as `[[Wiki Link]]`; initials, tooltip, and color now derive from the parsed display name ([#64](https://github.com/StepanKropachev/obsidian-pm/issues/64))
+- Renaming a task to a title that's already used by another file in the project now shows an inline error next to the title input
 
 ## [1.4.0] - 2026-04-29
 

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -2,6 +2,7 @@ import { App, ButtonComponent, Component, ExtraButtonComponent, Modal, MarkdownR
 import type PMPlugin from '../main'
 import { Project, Task, makeTask } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
+import { TaskFileNameConflictError } from '../store'
 import { safeAsync, getDefaultStatusId } from '../utils'
 import { renderStatusDot } from '../ui/StatusBadge'
 import { confirmDialog } from '../ui/ModalFactory'
@@ -65,7 +66,13 @@ export class TaskModal extends Modal {
       !this.saved &&
       this.task.title.trim()
     ) {
-      void this.persistTask()
+      const conflict = this.plugin.store.findTaskFileConflict(this.project, this.task)
+      if (conflict) {
+        const name = conflict.slice(conflict.lastIndexOf('/') + 1).replace(/\.md$/, '')
+        new Notice(`Task not saved: a note named "${name}" already exists.`)
+      } else {
+        void this.persistTask()
+      }
     }
     this.noteSuggest?.destroy()
     this.noteSuggest = null
@@ -74,8 +81,12 @@ export class TaskModal extends Modal {
 
   private persistTask(): Promise<void> {
     if (this.persistPromise) return this.persistPromise
-    this.persistPromise = this.runPersist()
-    return this.persistPromise
+    const p = this.runPersist()
+    this.persistPromise = p
+    p.catch(() => {
+      this.persistPromise = null
+    })
+    return p
   }
 
   private async insertAttachments(
@@ -123,14 +134,30 @@ export class TaskModal extends Modal {
     const header = contentEl.createDiv('pm-modal-header')
     renderStatusDot(header, this.task.status, this.plugin.settings.statuses, 'pm-modal-status-dot')
 
-    const titleInput = header.createEl('input', {
+    const titleWrap = header.createDiv('pm-modal-title-wrap')
+    const titleInput = titleWrap.createEl('input', {
       type: 'text',
       cls: 'pm-modal-title-input',
       value: this.task.title
     })
     titleInput.placeholder = 'Task title\u2026'
+    const titleError = titleWrap.createDiv({ cls: 'pm-modal-title-error', attr: { hidden: '' } })
+    const clearTitleError = () => {
+      if (titleError.hasAttribute('hidden')) return
+      titleError.setAttribute('hidden', '')
+      titleError.setText('')
+      titleInput.classList.remove('pm-input-error')
+    }
+    const showTitleError = (message: string) => {
+      titleError.setText(message)
+      titleError.removeAttribute('hidden')
+      titleInput.classList.add('pm-input-error')
+      titleInput.focus()
+      titleInput.select()
+    }
     titleInput.addEventListener('input', () => {
       this.task.title = titleInput.value
+      clearTitleError()
     })
     titleInput.focus()
     titleInput.select()
@@ -397,25 +424,45 @@ export class TaskModal extends Modal {
       .setButtonText(this.isNew ? 'Create (Shift+Enter)' : 'Save (Shift+Enter)')
       .setCta()
     let saving = false
-    const doSave = safeAsync(async () => {
+    const doSave = async () => {
       if (saving) return
       saving = true
-      if (!this.task.title.trim()) {
+      try {
+        if (!this.task.title.trim()) {
+          titleInput.focus()
+          titleInput.classList.add('pm-input-error')
+          return
+        }
+        clearTitleError()
+        const conflict = this.plugin.store.findTaskFileConflict(this.project, this.task)
+        if (conflict) {
+          const name = conflict.slice(conflict.lastIndexOf('/') + 1).replace(/\.md$/, '')
+          showTitleError(`A note named "${name}" already exists. Choose a different title.`)
+          return
+        }
+        await this.persistTask()
+        this.saved = true
+        this.close()
+      } catch (err) {
+        if (err instanceof TaskFileNameConflictError) {
+          const name = err.path.slice(err.path.lastIndexOf('/') + 1).replace(/\.md$/, '')
+          showTitleError(`A note named "${name}" already exists. Choose a different title.`)
+          return
+        }
+        console.error('[PM]', err)
+        new Notice('Something went wrong. Check the console for details.')
+      } finally {
         saving = false
-        titleInput.focus()
-        titleInput.classList.add('pm-input-error')
-        return
       }
-      await this.persistTask()
-      this.saved = true
-      this.close()
-    })
+    }
 
-    saveBtn.onClick(doSave)
+    saveBtn.onClick(() => {
+      void doSave()
+    })
     this.modalEl.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault()
-        doSave()
+        void doSave()
       }
     })
   }

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -34,6 +34,15 @@ function resolveTaskPath(task: Task, folder: string, previousPath: string | unde
   return desired
 }
 
+/** Thrown when saving a task would collide with an existing file in the vault. */
+export class TaskFileNameConflictError extends Error {
+  constructor(public readonly path: string) {
+    const name = path.slice(path.lastIndexOf('/') + 1).replace(/\.md$/, '')
+    super(`A note named "${name}" already exists.`)
+    this.name = 'TaskFileNameConflictError'
+  }
+}
+
 /**
  * Handles all read/write operations against the Obsidian vault.
  *
@@ -232,6 +241,7 @@ export class ProjectStore {
         await this.app.vault.create(project.filePath, content)
       }
     } catch (e) {
+      if (e instanceof TaskFileNameConflictError) throw e
       console.error(`[PM] Failed to save project "${project.title}":`, e)
       new Notice(`Project Manager: Failed to save "${project.title}". Check console for details.`)
       throw e
@@ -256,6 +266,7 @@ export class ProjectStore {
       }
     }
     if (errors.length) {
+      if (errors.length === 1 && errors[0] instanceof TaskFileNameConflictError) throw errors[0]
       throw new Error(`Failed to save ${errors.length} task(s): ${errors.map((e) => e.message).join('; ')}`)
     }
   }
@@ -264,7 +275,6 @@ export class ProjectStore {
     const previousPath = task.filePath
     const filePath = normalizePath(resolveTaskPath(task, folder, previousPath))
     const oldFilePath = previousPath && previousPath !== filePath ? previousPath : null
-    task.filePath = filePath
 
     try {
       // Write new file first, then delete old — prevents data loss if interrupted
@@ -272,12 +282,13 @@ export class ProjectStore {
       const existing = this.app.vault.getAbstractFileByPath(filePath)
       if (existing instanceof TFile) {
         if (existing.path !== previousPath) {
-          throw new Error(`Another file already exists at "${filePath}". Rename one task to resolve.`)
+          throw new TaskFileNameConflictError(filePath)
         }
         await this.app.vault.modify(existing, content)
       } else {
         await this.app.vault.create(filePath, content)
       }
+      task.filePath = filePath
 
       if (oldFilePath) {
         const oldFile = this.app.vault.getAbstractFileByPath(oldFilePath)
@@ -286,9 +297,25 @@ export class ProjectStore {
         }
       }
     } catch (e) {
-      console.error(`[PM] Failed to save task "${task.title}" (${task.id}):`, e)
+      if (!(e instanceof TaskFileNameConflictError)) {
+        console.error(`[PM] Failed to save task "${task.title}" (${task.id}):`, e)
+      }
       throw e
     }
+  }
+
+  /**
+   * Pre-flight check: would saving this task (at its current title) collide
+   * with another file already in the vault? Returns the conflicting path or
+   * null. Callers can surface this inline before triggering a save.
+   */
+  findTaskFileConflict(project: Project, task: Task): string | null {
+    const baseFolder = this.projectTaskFolder(project)
+    const folder = task.archived ? normalizePath(baseFolder + '/Archive') : baseFolder
+    const desired = normalizePath(resolveTaskPath(task, folder, task.filePath))
+    if (desired === task.filePath) return null
+    const existing = this.app.vault.getAbstractFileByPath(desired)
+    return existing instanceof TFile ? desired : null
   }
 
   // ─── CRUD shortcuts ────────────────────────────────────────────────────────

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,4 @@
-export { ProjectStore } from './ProjectStore'
+export { ProjectStore, TaskFileNameConflictError } from './ProjectStore'
 export { parseFrontmatter, appendYaml, isOldFormat } from './YamlParser'
 export { hydrateTasks } from './YamlHydrator'
 export { serializeProject, serializeTask } from './YamlSerializer'

--- a/styles.css
+++ b/styles.css
@@ -996,8 +996,16 @@
   flex-shrink: 0;
 }
 
-.pm-modal-title-input {
+.pm-modal-title-wrap {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 4px;
+}
+
+.pm-modal-title-input {
+  width: 100%;
   font-size: 20px;
   font-weight: 700;
   border: none;
@@ -1008,7 +1016,13 @@
   min-width: 0;
 }
 .pm-modal-title-input::placeholder { color: var(--pm-text-faint); }
-.pm-input-error { box-shadow: 0 0 0 2px var(--pm-danger); border-radius: 4px; }
+.pm-input-error { box-shadow: 0 0 0 2px var(--text-error); border-radius: 4px; }
+
+.pm-modal-title-error {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-error);
+}
+.pm-modal-title-error[hidden] { display: none; }
 
 /* Property rows */
 .pm-modal-props {


### PR DESCRIPTION
Renaming a task to a title that collides with another file dumped two stacked toasts and a `[PM] Failed to save task` traceback to the console. Now you get a small red message under the title input ("a note named X already exists, choose a different title") and a red ring on the input. Clears as you type.

Also fixes the modal's save button getting stuck after a failed save, and a path where the in-memory task could end up pointing at the colliding file.