### PR TITLE
tidy task filename conflict error handling

### DIFF
--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -68,8 +68,7 @@ export class TaskModal extends Modal {
     ) {
       const conflict = this.plugin.store.findTaskFileConflict(this.project, this.task)
       if (conflict) {
-        const name = conflict.slice(conflict.lastIndexOf('/') + 1).replace(/\.md$/, '')
-        new Notice(`Task not saved: a note named "${name}" already exists.`)
+        new Notice(`Task not saved: a note named "${conflict.fileName}" already exists.`)
       } else {
         void this.persistTask()
       }
@@ -434,19 +433,12 @@ export class TaskModal extends Modal {
           return
         }
         clearTitleError()
-        const conflict = this.plugin.store.findTaskFileConflict(this.project, this.task)
-        if (conflict) {
-          const name = conflict.slice(conflict.lastIndexOf('/') + 1).replace(/\.md$/, '')
-          showTitleError(`A note named "${name}" already exists. Choose a different title.`)
-          return
-        }
         await this.persistTask()
         this.saved = true
         this.close()
       } catch (err) {
         if (err instanceof TaskFileNameConflictError) {
-          const name = err.path.slice(err.path.lastIndexOf('/') + 1).replace(/\.md$/, '')
-          showTitleError(`A note named "${name}" already exists. Choose a different title.`)
+          showTitleError(`A note named "${err.fileName}" already exists. Choose a different title.`)
           return
         }
         console.error('[PM]', err)

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -37,10 +37,17 @@ function resolveTaskPath(task: Task, folder: string, previousPath: string | unde
 /** Thrown when saving a task would collide with an existing file in the vault. */
 export class TaskFileNameConflictError extends Error {
   constructor(public readonly path: string) {
-    const name = path.slice(path.lastIndexOf('/') + 1).replace(/\.md$/, '')
-    super(`A note named "${name}" already exists.`)
+    super(`A note named "${fileNameFromPath(path)}" already exists.`)
     this.name = 'TaskFileNameConflictError'
   }
+
+  get fileName(): string {
+    return fileNameFromPath(this.path)
+  }
+}
+
+function fileNameFromPath(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1).replace(/\.md$/, '')
 }
 
 /**
@@ -306,16 +313,16 @@ export class ProjectStore {
 
   /**
    * Pre-flight check: would saving this task (at its current title) collide
-   * with another file already in the vault? Returns the conflicting path or
-   * null. Callers can surface this inline before triggering a save.
+   * with another file already in the vault? Returns a typed error callers can
+   * surface inline, or null if the save would proceed cleanly.
    */
-  findTaskFileConflict(project: Project, task: Task): string | null {
+  findTaskFileConflict(project: Project, task: Task): TaskFileNameConflictError | null {
     const baseFolder = this.projectTaskFolder(project)
     const folder = task.archived ? normalizePath(baseFolder + '/Archive') : baseFolder
     const desired = normalizePath(resolveTaskPath(task, folder, task.filePath))
     if (desired === task.filePath) return null
     const existing = this.app.vault.getAbstractFileByPath(desired)
-    return existing instanceof TFile ? desired : null
+    return existing instanceof TFile ? new TaskFileNameConflictError(desired) : null
   }
 
   // ─── CRUD shortcuts ────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #68.

`TaskFileNameConflictError` grows a `fileName` getter and `findTaskFileConflict` returns the error itself, so the slice+replace name extraction lives in one place instead of four. The pre-flight conflict check in `doSave` is gone too — the surrounding catch around `persistTask` already handles it with the same message.