### PR TITLE
grant bump workflow the permissions release.yml needs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,6 +15,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: version-bump


### PR DESCRIPTION
release.yml requests id-token and attestations for build provenance. bump.yml calls it via workflow_call but only granted contents and pull-requests, so the run died at startup before any job scheduled.

Repro: https://github.com/StepanKropachev/obsidian-pm/actions/runs/26352592249