### PR TITLE
rewrite bump workflow to push straight to main

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
   id-token: write
   attestations: write
 
@@ -35,17 +34,17 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "must be dispatched from main (got $GITHUB_REF)" >&2
+            exit 1
+          fi
           if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
             echo "version '$VERSION' is not valid semver" >&2
             exit 1
           fi
           git fetch --tags origin
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+          if git show-ref --tags --verify --quiet "refs/tags/$VERSION"; then
             echo "tag $VERSION already exists" >&2
-            exit 1
-          fi
-          if git ls-remote --exit-code --heads origin "bump-$VERSION" >/dev/null 2>&1; then
-            echo "branch bump-$VERSION already exists on origin; delete it first" >&2
             exit 1
           fi
 
@@ -78,56 +77,16 @@ jobs:
           fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           EOF
 
-      - name: Push bump branch
+      - name: Commit, tag, and push
         env:
           VERSION: ${{ inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "bump-$VERSION"
           git add manifest.json versions.json package.json
           git commit -m "bump version to $VERSION"
-          git push -u origin "bump-$VERSION"
-
-      - name: Open PR
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          pr_url=$(gh pr create \
-            --base main \
-            --head "bump-$VERSION" \
-            --title "bump version to $VERSION" \
-            --body "Automated version bump to $VERSION.")
-          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for build check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ steps.pr.outputs.url }}
-        run: gh pr checks "$PR_URL" --watch --fail-fast --interval 10
-
-      - name: Merge PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ steps.pr.outputs.url }}
-        run: gh pr merge "$PR_URL" --squash --delete-branch
-
-      - name: Tag merge commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ steps.pr.outputs.url }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          sha=$(gh pr view "$PR_URL" --json mergeCommit -q .mergeCommit.oid)
-          if [ -z "$sha" ] || [ "$sha" = "null" ]; then
-            echo "could not resolve merge commit sha for $PR_URL" >&2
-            exit 1
-          fi
-          git fetch origin "$sha"
-          git tag "$VERSION" "$sha"
-          git push origin "$VERSION"
+          git tag "$VERSION"
+          git push --atomic origin HEAD:main "refs/tags/$VERSION"
 
   release:
     needs: bump


### PR DESCRIPTION
Skip the PR ceremony. Bump commits the version files, tags, and pushes both to main atomically, then chains into release.yml.

Also tightened the validate step (only allow dispatch from main; tag existence check now matches refs/tags only, not arbitrary refs).