### PR TITLE
fix subtasks toggle not working in the gantt view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Views update in place after an edit, preserving scroll position and selection
 - Select all in the table selects every task matching the current filter, not just the rows in view
 - Collapse state is stored in plugin settings instead of task frontmatter. Collapsing or expanding a subtree no longer modifies task files, and the `collapsed` frontmatter key is no longer written
+- Expand/collapse subtasks toggle is styled consistently across the table and Gantt views
 
 ### Fixed
 
 - Progress bar labels showing 0% instead of the actual value in some views
+- Subtasks toggle not working in the Gantt view
 
 ## [1.5.0] - 2026-05-25
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { MarkdownView, Plugin, Notice } from 'obsidian'
 import { DEFAULT_SETTINGS, PMSettings, Project } from './types'
-import { flattenTasks } from './store/TaskTreeOps'
+import { flattenTasks, findTask } from './store/TaskTreeOps'
 import { ProjectStore } from './store'
 import { PMSettingTab } from './settings'
 import { ProjectView, PM_PROJECT_VIEW_TYPE } from './views/ProjectView'
@@ -222,6 +222,17 @@ export default class PMPlugin extends Plugin {
       .filter((f) => f.task.collapsed)
       .map((f) => f.task.id)
     await this.saveSettings()
+  }
+
+  /**
+   * Flip a task's collapsed flag and persist. Resolves the task by id against
+   * the live tree so it works even when a view renders filtered clones.
+   */
+  async toggleTaskCollapsed(project: Project, taskId: string): Promise<void> {
+    const task = findTask(project.tasks, taskId)
+    if (!task) return
+    task.collapsed = !task.collapsed
+    await this.persistCollapsedState(project)
   }
 
   async saveSettings(): Promise<void> {

--- a/src/ui/composites/cells/ExpandCell.ts
+++ b/src/ui/composites/cells/ExpandCell.ts
@@ -1,4 +1,4 @@
-import { setIcon } from 'obsidian'
+import { CollapseToggle } from '../../primitives/CollapseToggle'
 
 export interface ExpandCellProps {
   hasSubtasks: boolean
@@ -12,11 +12,7 @@ export class ExpandCell {
   constructor(parentRow: HTMLElement, props: ExpandCellProps) {
     this.el = parentRow.createEl('td', { cls: 'pm-table-cell-expand' })
     if (props.hasSubtasks) {
-      const toggle = this.el.createDiv({ cls: 'tree-item-icon collapse-icon' })
-      setIcon(toggle, 'right-triangle')
-      toggle.toggleClass('is-collapsed', props.collapsed)
-      toggle.setAttr('aria-label', props.collapsed ? 'Expand subtasks' : 'Collapse subtasks')
-      toggle.addEventListener('click', props.onToggle)
+      new CollapseToggle(this.el, { collapsed: props.collapsed, onToggle: props.onToggle })
     }
   }
 }

--- a/src/ui/primitives/CollapseToggle.ts
+++ b/src/ui/primitives/CollapseToggle.ts
@@ -1,0 +1,18 @@
+import { setIcon } from 'obsidian'
+
+export interface CollapseToggleProps {
+  collapsed: boolean
+  onToggle: (e: MouseEvent) => unknown
+}
+
+export class CollapseToggle {
+  el: HTMLElement
+
+  constructor(parentEl: HTMLElement, props: CollapseToggleProps) {
+    this.el = parentEl.createDiv({ cls: 'tree-item-icon collapse-icon pm-collapse-toggle' })
+    setIcon(this.el, 'right-triangle')
+    this.el.toggleClass('is-collapsed', props.collapsed)
+    this.el.setAttr('aria-label', props.collapsed ? 'Expand subtasks' : 'Collapse subtasks')
+    this.el.addEventListener('click', props.onToggle)
+  }
+}

--- a/src/views/gantt/TaskLabelRenderer.ts
+++ b/src/views/gantt/TaskLabelRenderer.ts
@@ -1,7 +1,6 @@
-import { setIcon } from 'obsidian'
 import type PMPlugin from '../../main'
 import type { Project, Task } from '../../types'
-import { findTask } from '../../store/TaskTreeOps'
+import { CollapseToggle } from '../../ui/primitives/CollapseToggle'
 import { openTaskModal } from '../../ui/ModalFactory'
 import { COLOR_MUTED } from '../../constants'
 import { getStatusConfig, safeAsync } from '../../utils'
@@ -58,22 +57,15 @@ export function renderTaskLabel(
     })
   )
 
-  // Expand button
+  // Expand toggle
   if (task.subtasks.length > 0) {
-    const toggle = el.createDiv({ cls: 'tree-item-icon collapse-icon pm-gantt-expand-btn' })
-    setIcon(toggle, 'right-triangle')
-    toggle.toggleClass('is-collapsed', task.collapsed)
-    toggle.setAttr('aria-label', task.collapsed ? 'Expand subtasks' : 'Collapse subtasks')
-    toggle.addEventListener(
-      'click',
-      safeAsync(async () => {
-        const real = findTask(ctx.project.tasks, task.id)
-        if (!real) return
-        real.collapsed = !real.collapsed
-        await ctx.plugin.persistCollapsedState(ctx.project)
+    new CollapseToggle(el, {
+      collapsed: task.collapsed,
+      onToggle: safeAsync(async () => {
+        await ctx.plugin.toggleTaskCollapsed(ctx.project, task.id)
         await ctx.onRefresh()
       })
-    )
+    })
   } else {
     el.createSpan({ cls: 'pm-gantt-label-spacer' })
   }

--- a/src/views/gantt/TaskLabelRenderer.ts
+++ b/src/views/gantt/TaskLabelRenderer.ts
@@ -1,5 +1,7 @@
+import { setIcon } from 'obsidian'
 import type PMPlugin from '../../main'
 import type { Project, Task } from '../../types'
+import { findTask } from '../../store/TaskTreeOps'
 import { openTaskModal } from '../../ui/ModalFactory'
 import { COLOR_MUTED } from '../../constants'
 import { getStatusConfig, safeAsync } from '../../utils'
@@ -58,14 +60,16 @@ export function renderTaskLabel(
 
   // Expand button
   if (task.subtasks.length > 0) {
-    const btn = el.createEl('button', {
-      text: task.collapsed ? '▶' : '▼',
-      cls: 'pm-gantt-expand-btn'
-    })
-    btn.addEventListener(
+    const toggle = el.createDiv({ cls: 'tree-item-icon collapse-icon pm-gantt-expand-btn' })
+    setIcon(toggle, 'right-triangle')
+    toggle.toggleClass('is-collapsed', task.collapsed)
+    toggle.setAttr('aria-label', task.collapsed ? 'Expand subtasks' : 'Collapse subtasks')
+    toggle.addEventListener(
       'click',
       safeAsync(async () => {
-        task.collapsed = !task.collapsed
+        const real = findTask(ctx.project.tasks, task.id)
+        if (!real) return
+        real.collapsed = !real.collapsed
         await ctx.plugin.persistCollapsedState(ctx.project)
         await ctx.onRefresh()
       })

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -70,8 +70,7 @@ export function renderTaskRow(tbody: HTMLElement, task: Task, depth: number, ctx
     hasSubtasks: task.subtasks.length > 0,
     collapsed: task.collapsed,
     onToggle: safeAsync(async () => {
-      task.collapsed = !task.collapsed
-      await ctx.plugin.persistCollapsedState(ctx.project)
+      await ctx.plugin.toggleTaskCollapsed(ctx.project, task.id)
       await ctx.onRefresh()
     })
   })

--- a/styles.css
+++ b/styles.css
@@ -673,17 +673,17 @@
 .pm-gantt-label-row:hover { background: var(--pm-bg3); }
 
 .pm-gantt-expand-btn {
-  background: transparent;
-  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  color: var(--pm-text-muted);
-  font-size: 10px;
-  padding: 2px;
+  color: var(--text-muted);
   flex-shrink: 0;
-  transition: color 0.15s;
-  line-height: 1;
+  padding: 2px;
+  --icon-size: 14px;
 }
-.pm-gantt-expand-btn:hover { color: var(--pm-text); }
+.pm-gantt-expand-btn:hover { color: var(--text-normal); }
+.pm-gantt-expand-btn.is-collapsed .svg-icon { transform: rotate(-90deg); }
 .pm-gantt-label-spacer { width: 16px; flex-shrink: 0; }
 
 .pm-gantt-label-dot {

--- a/styles.css
+++ b/styles.css
@@ -372,15 +372,18 @@
   pointer-events: auto;
 }
 .pm-table-cell-expand { width: 32px; text-align: center; padding: 0; }
-.pm-table-cell-expand .collapse-icon {
+
+.pm-collapse-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   color: var(--text-muted);
+  flex-shrink: 0;
+  --icon-size: 14px;
 }
-.pm-table-cell-expand .collapse-icon:hover { color: var(--text-normal); }
-.pm-table-cell-expand .collapse-icon.is-collapsed .svg-icon { transform: rotate(-90deg); }
+.pm-collapse-toggle:hover { color: var(--text-normal); }
+.pm-collapse-toggle.is-collapsed .svg-icon { transform: rotate(-90deg); }
 .pm-table-cell-progress { min-width: 120px; }
 .pm-table-cell-actions { width: 40px; text-align: center; }
 .pm-table-cell-assignees { min-width: 80px; }
@@ -672,18 +675,6 @@
 }
 .pm-gantt-label-row:hover { background: var(--pm-bg3); }
 
-.pm-gantt-expand-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--text-muted);
-  flex-shrink: 0;
-  padding: 2px;
-  --icon-size: 14px;
-}
-.pm-gantt-expand-btn:hover { color: var(--text-normal); }
-.pm-gantt-expand-btn.is-collapsed .svg-icon { transform: rotate(-90deg); }
 .pm-gantt-label-spacer { width: 16px; flex-shrink: 0; }
 
 .pm-gantt-label-dot {


### PR DESCRIPTION
The Gantt view renders filtered clones of the task tree, so clicking the collapse toggle flipped `collapsed` on a throwaway copy and the change got dropped on the next render. Now it resolves the task by id against the live tree before toggling.

Also pulls the toggle markup, styling, and logic into one shared primitive + plugin method used by both the table and Gantt views.