### PR TITLE
run build and test checks on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 jobs:
   test:


### PR DESCRIPTION
The Build and Test workflows trigger on `push` only. Push events run in the repository the push lands in, so pull requests opened from forks never trigger them in this repo, and those PRs show no status checks.

Adding a `pull_request` trigger (same `paths-ignore`) so build, submission lint, and tests run against every PR, including forks. `pull_request` runs in the base repo against the merge ref with secrets withheld for forks, which is fine here since these jobs need no secrets.

Trade-off: a branch pushed to this repo that also has an open PR will run each workflow twice (once per event). Can scope the push trigger to `main` if that's noisy.