### PR TITLE
Bump shell-quote to 1.8.4 (CVE-2026-9277)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     "vitest": "4.1.5",
     "yaml": "2.8.3"
   },
+  "pnpm": {
+    "overrides": {
+      "shell-quote@<1.8.4": "1.8.4"
+    }
+  },
   "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=24"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  shell-quote@<1.8.4: 1.8.4
+
 importers:
 
   .:
@@ -2047,8 +2050,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -4161,7 +4164,7 @@ snapshots:
       picomatch: 4.0.4
       pidtree: 0.6.0
       read-package-json-fast: 4.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       which: 5.0.0
 
   object-assign@4.1.1: {}
@@ -4499,7 +4502,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.1:
     dependencies:


### PR DESCRIPTION
Closes Dependabot alert #6.

## What
Pins the transitive `shell-quote` dependency (pulled in via `npm-run-all2`) to the patched **1.8.4** through a pnpm override.

## Why
`GHSA-w7jw-789q-3m8p` / `CVE-2026-9277` (critical): `quote()` failed to escape newlines in object-token `.op` values, allowing shell command injection when attacker-controlled object tokens reach `quote()`.

In this repo the package is a **dev-only transitive dependency** and the vulnerable path isn't reachable (`npm-run-all2` only quotes our own script names), so there's no practical risk — but the override is a one-line, dev-only change that clears the critical alert.

## Verification
- `shell-quote` resolves to `1.8.4` everywhere in `pnpm-lock.yaml`
- `pnpm install` clean (only pre-existing peer warnings)
- `pnpm build` passes