### PR TITLE
run build and test once per pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'docs/**'
       - '*.md'


### PR DESCRIPTION
The push trigger fires on every branch, so opening a PR ran build and test twice (push plus pull_request). Scopes push to main; pull_request keeps covering branches.