### PR TITLE
fix duplicate task with subtasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Duplicating a task with its subtasks failed with a "note already exists" error and dropped the subtasks. Copies of a subtree now get distinct file names ([#90](https://github.com/StepanKropachev/obsidian-pm/issues/90))
 - Progress bar labels showing 0% instead of the actual value in some views
 - Subtasks toggle not working in the Gantt view
 

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -375,6 +375,35 @@ describe('ProjectStore task index', () => {
     }
   })
 
+  it('duplicates a task with subtasks without colliding on filenames', async () => {
+    const { store, vault } = newStore()
+    const project = await store.createProject('Dup', 'Projects')
+    const parent = await addNamed(store, project, 'Parent')
+    await addNamed(store, project, 'subtask', parent.id)
+
+    const copy = await store.duplicateTask(project, parent.id, true)
+    expect(copy).not.toBeNull()
+
+    const paths = flattenTasks(project.tasks).map((f) => f.task.filePath)
+    expect(new Set(paths).size).toBe(paths.length)
+    for (const p of paths) {
+      expect(p).toBeTruthy()
+      expect(vault.getAbstractFileByPath(p!)).toBeInstanceOf(TFile)
+    }
+  })
+
+  it('disambiguates the copy title when the same task is duplicated twice', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Dup2', 'Projects')
+    const task = await addNamed(store, project, 'Task')
+
+    const first = await store.duplicateTask(project, task.id, false)
+    const second = await store.duplicateTask(project, task.id, false)
+
+    expect(first?.title).toBe('Task (copy)')
+    expect(second?.title).toBe('Task (copy 2)')
+  })
+
   it('survives a reload: rebuilt index after load matches the in-memory tree', async () => {
     const { store, vault, app } = newStore()
     const project = await store.createProject('Reload', 'Projects')

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -674,11 +674,24 @@ export class ProjectStore {
     const source = findTaskById(project, sourceId)
     if (!source) return null
     const copy = cloneTaskSubtree(source, includeSubtasks)
-    copy.title = `${source.title} (copy)`
+    // Every task in a project shares one flat folder and its filename comes from
+    // the title slug, so a clone that keeps the source title would write over the
+    // original. Reserve a free "(copy)" title for the whole subtree, not just the
+    // root, and across the clones we're about to add so siblings don't collide.
+    const baseFolder = this.projectTaskFolder(project)
+    const claimed = new Set<string>()
+    const claimTitle = (task: Task): void => {
+      const folder = task.archived ? normalizePath(baseFolder + '/Archive') : baseFolder
+      task.title = this.freeCopyTitle(task.title, folder, claimed)
+    }
     // Clones don't have a filePath yet; their description in memory is whatever
     // came from the source. We need to write that body verbatim.
+    claimTitle(copy)
     this.hydratedBodies.add(copy)
-    for (const ft of flattenTasks(copy.subtasks)) this.hydratedBodies.add(ft.task)
+    for (const ft of flattenTasks(copy.subtasks)) {
+      claimTitle(ft.task)
+      this.hydratedBodies.add(ft.task)
+    }
     const parentId = findParentId(project, sourceId)
     addTaskToTree(project.tasks, copy, parentId)
     moveTaskInTree(project.tasks, copy.id, sourceId, 'after')
@@ -688,6 +701,23 @@ export class ProjectStore {
     if (parentId) this.markDirty(project, [parentId], 'full')
     await this.saveProject(project)
     return copy
+  }
+
+  /**
+   * Pick a "(copy)" title for a duplicated task whose file isn't already taken,
+   * neither on disk nor by an earlier clone in the same duplication (`claimed`).
+   * A duplicate never reuses the bare source title, so the sequence starts at
+   * "(copy)" and counts up.
+   */
+  private freeCopyTitle(base: string, folder: string, claimed: Set<string>): string {
+    for (let n = 1; ; n++) {
+      const title = n === 1 ? `${base} (copy)` : `${base} (copy ${n})`
+      const path = normalizePath(taskFilePath(title, folder))
+      if (!claimed.has(path) && !(this.app.vault.getAbstractFileByPath(path) instanceof TFile)) {
+        claimed.add(path)
+        return title
+      }
+    }
   }
 
   async moveTask(project: Project, taskId: string, newParentId: string | null): Promise<void> {


### PR DESCRIPTION
Cloned subtasks reused the source file name, so duplicating a task with subtasks errored out and dropped them. Each copy in the subtree gets a unique name now.

Fixes #90