### PR TITLE
increase contrast between completed and remaining gantt progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Select all in the table selects every task matching the current filter, not just the rows in view
 - Collapse state is stored in plugin settings instead of task frontmatter. Collapsing or expanding a subtree no longer modifies task files, and the `collapsed` frontmatter key is no longer written
 - Expand/collapse subtasks toggle is styled consistently across the table and Gantt views
+- Gantt task bars use stronger contrast between completed and remaining work ([#87](https://github.com/StepanKropachev/obsidian-pm/issues/87))
 
 ### Fixed
 

--- a/src/views/gantt/GanttTaskBarRenderer.ts
+++ b/src/views/gantt/GanttTaskBarRenderer.ts
@@ -73,13 +73,13 @@ export function renderTaskBar(g: SVGGElement, task: Task, row: number, _depth: n
     rx: BAR_BORDER_RADIUS,
     ry: BAR_BORDER_RADIUS,
     fill: color,
-    opacity: 0.75,
+    opacity: 0.4,
     class: 'pm-gantt-bar'
   })
   barGroup.appendChild(rect)
 
-  // Progress overlay
-  if (task.progress > 0 && task.progress < 100) {
+  // Completed portion — solid fill over the faint track so progress reads at a glance
+  if (task.progress > 0) {
     const pw = (task.progress / 100) * width
     barGroup.appendChild(
       svgEl('rect', {
@@ -90,7 +90,7 @@ export function renderTaskBar(g: SVGGElement, task: Task, row: number, _depth: n
         rx: BAR_BORDER_RADIUS,
         ry: BAR_BORDER_RADIUS,
         fill: color,
-        opacity: 0.35,
+        opacity: 0.9,
         class: 'pm-gantt-bar-progress'
       })
     )

--- a/styles.css
+++ b/styles.css
@@ -771,7 +771,7 @@
   cursor: pointer;
   transition: filter 0.15s;
 }
-.pm-gantt-bar:hover { opacity: 0.9 !important; }
+.pm-gantt-bar:hover { filter: brightness(1.15); }
 .pm-gantt-bar-sheen { pointer-events: none; }
 .pm-gantt-bar-progress { pointer-events: none; }
 .pm-gantt-bar-label {
@@ -782,6 +782,7 @@
   letter-spacing: 0.03em;
   pointer-events: none;
   dominant-baseline: central;
+  text-shadow: 0 0 3px rgba(0,0,0,0.55);
 }
 
 /* Today line */


### PR DESCRIPTION
Completed and remaining parts of a gantt bar were the same color at almost the same opacity, so you couldn't really tell them apart. Now the completed part is solid over a faint track.

Closes #87