### PR TITLE
stamp a completion date on tasks entering a complete status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Completing a task records a completion date, shown in the task modal and stored in frontmatter ([#93](https://github.com/StepanKropachev/obsidian-pm/issues/93))
 - Setting "Show description preview on board" (default off) shows the first few lines of each task description on kanban cards, with markdown stripped and clamped to three lines ([#59](https://github.com/StepanKropachev/obsidian-pm/issues/59))
 
 ### Changed

--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -154,6 +154,14 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
     return input
   })
 
+  // Completed date — read-only, auto-stamped when the task enters a complete status.
+  if (task.completed) {
+    renderPropRow(container, 'Completed', () => {
+      const span = createSpan({ text: task.completed, cls: 'pm-prop-value pm-prop-completed' })
+      return span
+    })
+  }
+
   // Recurrence
   renderPropRow(container, 'Repeat', () => {
     const wrap = createDiv('pm-prop-value pm-prop-recurrence')

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -241,6 +241,73 @@ describe('ProjectStore round-trip', () => {
   })
 })
 
+describe('ProjectStore completion date', () => {
+  const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+  it('stamps completed when a task enters a complete status and clears it on exit', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Done dates', 'Projects')
+    const task = await addNamed(store, project, 'Ship it')
+    expect(task.completed).toBe('')
+
+    await store.updateTask(project, task.id, { status: 'done' })
+    expect(task.completed).toMatch(ISO_DATE)
+
+    await store.updateTask(project, task.id, { status: 'in-progress' })
+    expect(task.completed).toBe('')
+  })
+
+  it('does not restamp when status changes between two complete statuses or stays put', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Stable', 'Projects')
+    const task = await addNamed(store, project, 'Edit me')
+    await store.updateTask(project, task.id, { status: 'done' })
+    const stamped = task.completed
+    expect(stamped).toMatch(ISO_DATE)
+
+    // A non-status edit leaves the date alone.
+    await store.updateTask(project, task.id, { title: 'Edited' })
+    expect(task.completed).toBe(stamped)
+  })
+
+  it('persists the completion date across a reload', async () => {
+    const { store, vault, app } = newStore()
+    const project = await store.createProject('Persisted', 'Projects')
+    const task = await addNamed(store, project, 'Archive me')
+    await store.updateTask(project, task.id, { status: 'done' })
+
+    const store2 = new ProjectStore(app, () => STATUSES)
+    const file = vault.getAbstractFileByPath(project.filePath)
+    if (!(file instanceof TFile)) throw new Error('project file missing')
+    const reloaded = await store2.loadProject(file)
+    if (!reloaded) throw new Error('reload failed')
+    const reloadedTask = flattenTasks(reloaded.tasks).find((f) => f.task.id === task.id)!.task
+    expect(reloadedTask.completed).toMatch(ISO_DATE)
+  })
+
+  it('stamps a task inserted directly in a complete status', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Insert done', 'Projects')
+    const task = makeTask({ title: 'Born done', status: 'done' })
+    await store.insertTask(project, task)
+    expect(task.completed).toMatch(ISO_DATE)
+  })
+
+  it('does not bleed one task completion date onto another in a bulk update', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Bulk', 'Projects')
+    const open = await addNamed(store, project, 'Still open')
+    const finishing = await addNamed(store, project, 'Finishing')
+    await store.updateTask(project, finishing.id, { status: 'done' })
+    open.completed = ''
+
+    // A shared patch object applied to a task that is already done must not carry
+    // a stamped date onto the open task in the same call.
+    await store.updateTasks(project, [finishing.id, open.id], { priority: 'high' })
+    expect(open.completed).toBe('')
+  })
+})
+
 describe('ProjectStore metadataCache fast path', () => {
   function stubTaskCache(app: App, path: string, fm: Record<string, unknown>): void {
     const cache = (app as unknown as { metadataCache: { getFileCache: (f: TFile) => unknown } }).metadataCache

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -2,6 +2,8 @@ import type { Plugin, TAbstractFile } from 'obsidian'
 import { App, Notice, TFile, TFolder, normalizePath } from 'obsidian'
 import type { Project, StatusConfig, Task } from '../types'
 import { makeProject, makeTask } from '../types'
+import { today } from '../dates'
+import { isTerminalStatus } from '../utils'
 import { archiveTask as doArchiveTask, unarchiveTask as doUnarchiveTask } from './ArchiveOps'
 import { computeSchedule } from './Scheduler'
 import {
@@ -662,6 +664,9 @@ export class ProjectStore {
   }
 
   async insertTask(project: Project, task: Task, parentId: string | null = null): Promise<void> {
+    if (!task.completed && isTerminalStatus(task.status, this.getStatuses())) {
+      task.completed = today().toString()
+    }
     this.hydratedBodies.add(task)
     addTaskToTree(project.tasks, task, parentId)
     indexAddSubtree(project, task, parentId)
@@ -750,9 +755,25 @@ export class ProjectStore {
     await this.saveProject(project)
   }
 
+  /**
+   * Stamp or clear `completed` based on a status transition. Mutates `patch` so the
+   * date lands in the same save as the status change. Only fires when the patch
+   * changes status across the complete/incomplete boundary, so an explicit
+   * `completed` already in the patch (e.g. an import) is left untouched.
+   */
+  private stampCompletion(oldStatus: string, patch: Partial<Task>): void {
+    if (patch.status === undefined || patch.completed !== undefined) return
+    const statuses = this.getStatuses()
+    const wasComplete = isTerminalStatus(oldStatus, statuses)
+    const nowComplete = isTerminalStatus(patch.status, statuses)
+    if (nowComplete && !wasComplete) patch.completed = today().toString()
+    else if (!nowComplete && wasComplete) patch.completed = ''
+  }
+
   async updateTask(project: Project, taskId: string, patch: Partial<Task>): Promise<void> {
     const task = findTaskById(project, taskId)
     const oldTitle = task?.title
+    if (task) this.stampCompletion(task.status, patch)
     updateTaskInTree(project.tasks, taskId, patch)
     const titleChanged = task && patch.title !== undefined && patch.title !== oldTitle
     // Title change renames the file, which forces the rename branch in saveTaskFile
@@ -780,8 +801,12 @@ export class ProjectStore {
     for (const id of taskIds) {
       const task = findTaskById(project, id)
       if (!task) continue
-      const p = typeof patch === 'function' ? patch(task) : patch
-      if (!p) continue
+      const raw = typeof patch === 'function' ? patch(task) : patch
+      if (!raw) continue
+      // Copy a shared patch object before stamping so one task's completion date
+      // doesn't bleed onto the next iteration through the same reference.
+      const p = { ...raw }
+      this.stampCompletion(task.status, p)
       const oldTitle = task.title
       updateTaskInTree(project.tasks, id, p)
       const titleChanged = p.title !== undefined && p.title !== oldTitle

--- a/src/store/YamlHydrator.ts
+++ b/src/store/YamlHydrator.ts
@@ -46,6 +46,7 @@ export function mapRawToTask(r: Record<string, unknown>, overrides?: Partial<Tas
     start: (r.start as string) ?? '',
     due: (r.due as string) ?? '',
     progress: typeof r.progress === 'number' ? r.progress : 0,
+    completed: (r.completed as string) ?? '',
     // Copy container fields rather than aliasing them. On the metadataCache
     // fast path `r` is Obsidian's live frontmatter object, so a shared array or
     // object would let an in-place task mutation corrupt the cache.

--- a/src/store/YamlSerializer.ts
+++ b/src/store/YamlSerializer.ts
@@ -74,6 +74,7 @@ export function buildTaskFrontmatter(task: Task, project: Project, parentTask: T
     createdAt: task.createdAt,
     updatedAt: task.updatedAt
   }
+  if (task.completed) fm.completed = task.completed
   if (task.recurrence) fm.recurrence = task.recurrence
   if (task.timeEstimate !== undefined) fm.timeEstimate = task.timeEstimate
   if (task.timeLogs?.length) fm.timeLogs = task.timeLogs

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface Task {
   start: string // YYYY-MM-DD, empty string = unset
   due: string // YYYY-MM-DD, empty string = unset
   progress: number // 0–100
+  completed: string // YYYY-MM-DD, empty string = not completed; stamped when status becomes complete
   assignees: string[]
   tags: string[]
   subtasks: Task[]
@@ -185,6 +186,7 @@ export function makeTask(overrides: Partial<Task> = {}): Task {
     start: today().toString(),
     due: '',
     progress: 0,
+    completed: '',
     assignees: [],
     tags: [],
     subtasks: [],

--- a/styles.css
+++ b/styles.css
@@ -1096,6 +1096,8 @@
 }
 .pm-prop-date:focus { border-color: var(--pm-accent); outline: none; }
 
+.pm-prop-completed { color: var(--text-muted); font-size: 13px; }
+
 .pm-prop-text, .pm-prop-select {
   padding: 5px 8px;
   border: 1px solid var(--pm-border);


### PR DESCRIPTION
Closes #93. Auto-stamps a `completed` frontmatter date when a task enters a complete status and clears it when it leaves, so completion dates are queryable across the vault.