### PR TITLE
make the completion date editable and stamp it when completing via the modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Completing a task records a completion date, shown in the task modal and stored in frontmatter ([#93](https://github.com/StepanKropachev/obsidian-pm/issues/93))
+- Completing a task records a completion date, editable in the task modal and stored in frontmatter ([#93](https://github.com/StepanKropachev/obsidian-pm/issues/93))
 - Setting "Show description preview on board" (default off) shows the first few lines of each task description on kanban cards, with markdown stripped and clamped to three lines ([#59](https://github.com/StepanKropachev/obsidian-pm/issues/59))
 
 ### Changed

--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -7,7 +7,7 @@ import { renderPropRow, renderProgressSlider, renderChipList } from '../ui/FormF
 import { Badge } from '../ui/primitives/Badge'
 import { SegmentedControl } from '../ui/primitives/SegmentedControl'
 import { COLOR_MUTED } from '../constants'
-import { getStatusConfig, getPriorityConfig, formatBadgeText } from '../utils'
+import { getStatusConfig, getPriorityConfig, formatBadgeText, isTerminalStatus } from '../utils'
 import { renderCustomFieldInput } from './CustomFieldInputs'
 import { TaskPickerModal, TagPickerModal } from './PickerModals'
 
@@ -154,11 +154,16 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
     return input
   })
 
-  // Completed date — read-only, auto-stamped when the task enters a complete status.
-  if (task.completed) {
+  // Completed date — auto-stamped when the task enters a complete status, but editable.
+  // Shown once the task is in a complete status or already carries a date.
+  if (task.completed || isTerminalStatus(task.status, plugin.settings.statuses)) {
     renderPropRow(container, 'Completed', () => {
-      const span = createSpan({ text: task.completed, cls: 'pm-prop-value pm-prop-completed' })
-      return span
+      const input = createEl('input', { type: 'date', cls: 'pm-prop-value pm-prop-date' })
+      input.value = task.completed
+      input.addEventListener('change', () => {
+        task.completed = input.value
+      })
+      return input
     })
   }
 

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -270,6 +270,24 @@ describe('ProjectStore completion date', () => {
     expect(task.completed).toBe(stamped)
   })
 
+  it('stamps from a full-task patch that already carries the unchanged completed field', async () => {
+    // The task modal saves the whole task as the patch, so `completed` is present
+    // and equal to the stored value. Auto-stamping must still fire on the status flip.
+    const { store } = newStore()
+    const project = await store.createProject('Modal', 'Projects')
+    const task = await addNamed(store, project, 'Via modal')
+    await store.updateTask(project, task.id, { ...task, status: 'done', completed: '' })
+    expect(task.completed).toMatch(ISO_DATE)
+  })
+
+  it('respects an explicit completion date in the patch over auto-stamping', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Manual', 'Projects')
+    const task = await addNamed(store, project, 'Backdated')
+    await store.updateTask(project, task.id, { status: 'done', completed: '2025-01-15' })
+    expect(task.completed).toBe('2025-01-15')
+  })
+
   it('persists the completion date across a reload', async () => {
     const { store, vault, app } = newStore()
     const project = await store.createProject('Persisted', 'Projects')

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -757,14 +757,20 @@ export class ProjectStore {
 
   /**
    * Stamp or clear `completed` based on a status transition. Mutates `patch` so the
-   * date lands in the same save as the status change. Only fires when the patch
-   * changes status across the complete/incomplete boundary, so an explicit
-   * `completed` already in the patch (e.g. an import) is left untouched.
+   * date lands in the same save as the status change. A patch that changes
+   * `completed` away from the task's current value (a manual edit in the modal, or
+   * an import) wins and is left untouched; otherwise crossing the
+   * complete/incomplete boundary stamps today's date or clears it.
+   *
+   * The modal saves the whole task as the patch, so `patch.completed` is almost
+   * always present and equal to the stored value — comparing against the task,
+   * not just checking presence, is what lets auto-stamping fire from the modal.
    */
-  private stampCompletion(oldStatus: string, patch: Partial<Task>): void {
-    if (patch.status === undefined || patch.completed !== undefined) return
+  private stampCompletion(task: Task, patch: Partial<Task>): void {
+    if (patch.status === undefined) return
+    if (patch.completed !== undefined && patch.completed !== task.completed) return
     const statuses = this.getStatuses()
-    const wasComplete = isTerminalStatus(oldStatus, statuses)
+    const wasComplete = isTerminalStatus(task.status, statuses)
     const nowComplete = isTerminalStatus(patch.status, statuses)
     if (nowComplete && !wasComplete) patch.completed = today().toString()
     else if (!nowComplete && wasComplete) patch.completed = ''
@@ -773,7 +779,7 @@ export class ProjectStore {
   async updateTask(project: Project, taskId: string, patch: Partial<Task>): Promise<void> {
     const task = findTaskById(project, taskId)
     const oldTitle = task?.title
-    if (task) this.stampCompletion(task.status, patch)
+    if (task) this.stampCompletion(task, patch)
     updateTaskInTree(project.tasks, taskId, patch)
     const titleChanged = task && patch.title !== undefined && patch.title !== oldTitle
     // Title change renames the file, which forces the rename branch in saveTaskFile
@@ -806,7 +812,7 @@ export class ProjectStore {
       // Copy a shared patch object before stamping so one task's completion date
       // doesn't bleed onto the next iteration through the same reference.
       const p = { ...raw }
-      this.stampCompletion(task.status, p)
+      this.stampCompletion(task, p)
       const oldTitle = task.title
       updateTaskInTree(project.tasks, id, p)
       const titleChanged = p.title !== undefined && p.title !== oldTitle

--- a/styles.css
+++ b/styles.css
@@ -1096,8 +1096,6 @@
 }
 .pm-prop-date:focus { border-color: var(--pm-accent); outline: none; }
 
-.pm-prop-completed { color: var(--text-muted); font-size: 13px; }
-
 .pm-prop-text, .pm-prop-select {
   padding: 5px 8px;
   border: 1px solid var(--pm-border);


### PR DESCRIPTION
Follow-up to #105. The completion date is now an editable field in the task modal, and completing a task from the modal correctly stamps the date (it previously only stamped from the board and table).