### PR TITLE
clear oxlint warnings across src and tests

### DIFF
--- a/src/modals/ImportModal.ts
+++ b/src/modals/ImportModal.ts
@@ -20,7 +20,6 @@ export class ImportModal extends Modal {
   private nextButton: HTMLButtonElement | null = null
   private fileListContainer: HTMLDivElement | null = null
   private counterLabel: HTMLDivElement | null = null
-  private onConfirm: ((selectedFiles: TFile[]) => void) | null = null
 
   // Phase 2 state
   private phase: 1 | 2 = 1
@@ -223,14 +222,15 @@ export class ImportModal extends Modal {
   }
 
   private renderFileList(): void {
-    if (!this.fileListContainer) return
+    const fileListContainer = this.fileListContainer
+    if (!fileListContainer) return
 
     // Clear existing items (keep the select-all row)
-    const items = this.fileListContainer.querySelectorAll('.import-file-item')
+    const items = fileListContainer.querySelectorAll('.import-file-item')
     items.forEach((item) => item.remove())
 
     this.filteredFiles.forEach((item) => {
-      const row = this.fileListContainer!.createDiv('import-file-item suggestion-item')
+      const row = fileListContainer.createDiv('import-file-item suggestion-item')
       this.applyRowStyles(row, item.selected)
 
       const checkbox = row.createEl('input', { type: 'checkbox' })
@@ -405,15 +405,11 @@ export class ImportModal extends Modal {
     }
   }
 
-  setOnConfirm(callback: (selectedFiles: TFile[]) => void): void {
-    this.onConfirm = callback
-  }
-
   setProject(project: Project): void {
     this.project = project
   }
 
-  setOnImportComplete(callback: () => void): void {
-    this.onImportComplete = callback
+  setOnImportComplete(handler: () => void): void {
+    this.onImportComplete = handler
   }
 }

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -80,11 +80,15 @@ export class TaskModal extends Modal {
 
   private persistTask(): Promise<void> {
     if (this.persistPromise) return this.persistPromise
-    const p = this.runPersist()
+    const p = (async () => {
+      try {
+        await this.runPersist()
+      } catch (err) {
+        this.persistPromise = null
+        throw err
+      }
+    })()
     this.persistPromise = p
-    p.catch(() => {
-      this.persistPromise = null
-    })
     return p
   }
 

--- a/src/modals/TimeTrackingPanel.ts
+++ b/src/modals/TimeTrackingPanel.ts
@@ -42,8 +42,9 @@ export function renderTimeTrackingPanel(container: HTMLElement, task: Task): voi
   const renderLogs = () => {
     logList.empty()
     if (!task.timeLogs) task.timeLogs = []
-    for (let i = 0; i < task.timeLogs.length; i++) {
-      const log = task.timeLogs[i]
+    const logs = task.timeLogs
+    for (let i = 0; i < logs.length; i++) {
+      const log = logs[i]
       const row = logList.createDiv('pm-time-log-row')
 
       const dateInput = row.createEl('input', { type: 'date', cls: 'pm-prop-date pm-time-log-date' })
@@ -71,7 +72,7 @@ export function renderTimeTrackingPanel(container: HTMLElement, task: Task): voi
       const rmBtn = row.createEl('button', { text: '\u2715', cls: 'pm-subtask-rm' })
       rmBtn.addClass('pm-subtask-rm--visible')
       rmBtn.addEventListener('click', () => {
-        task.timeLogs!.splice(i, 1)
+        logs.splice(i, 1)
         renderLogs()
       })
     }

--- a/src/store/ArchiveOps.ts
+++ b/src/store/ArchiveOps.ts
@@ -17,7 +17,8 @@ export async function archiveTask(app: App, project: Project, taskId: string): P
   const archiveFolder = normalizePath(taskFolder + '/Archive')
   await ensureFolder(app, archiveFolder)
 
-  const fileName = task.filePath.split('/').pop()!
+  const fileName = task.filePath.split('/').pop()
+  if (!fileName) return
   const newPath = normalizePath(archiveFolder + '/' + fileName)
 
   const file = app.vault.getAbstractFileByPath(task.filePath)
@@ -35,7 +36,8 @@ export async function unarchiveTask(app: App, project: Project, taskId: string):
   if (!task || !task.filePath) return
 
   const taskFolder = projectTaskFolder(project)
-  const fileName = task.filePath.split('/').pop()!
+  const fileName = task.filePath.split('/').pop()
+  if (!fileName) return
   const newPath = normalizePath(taskFolder + '/' + fileName)
 
   const file = app.vault.getAbstractFileByPath(task.filePath)

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -7,6 +7,11 @@ import { ProjectStore } from './ProjectStore'
 import { buildTaskIndex } from './TaskIndex'
 import { flattenTasks } from './TaskTreeOps'
 
+const expectDefined = <T>(value: T | null | undefined, message = 'expected value to be defined'): T => {
+  if (value == null) throw new Error(message)
+  return value
+}
+
 const STATUSES: StatusConfig[] = [
   { id: 'todo', label: 'Todo', color: '#888', icon: 'circle', complete: false },
   { id: 'in-progress', label: 'In progress', color: '#88f', icon: 'loader', complete: false },
@@ -50,22 +55,22 @@ describe('ProjectStore self-write tracking', () => {
 
     await store.updateTask(project, task.id, { status: 'in-progress' })
 
-    expect(store.consumeSelfWrite(task.filePath!)).toBe(true)
-    expect(store.consumeSelfWrite(task.filePath!)).toBe(false) // single-use
+    expect(store.consumeSelfWrite(expectDefined(task.filePath))).toBe(true)
+    expect(store.consumeSelfWrite(expectDefined(task.filePath))).toBe(false) // single-use
   })
 
   it('marks both old and new path on title rename (modify new, trash old)', async () => {
     const { store, vault } = newStore()
     const project = await store.createProject('R', 'Projects')
     const task = await addNamed(store, project, 'Before')
-    const oldPath = task.filePath!
+    const oldPath = expectDefined(task.filePath)
     vault.resetCounts()
 
     await store.updateTask(project, task.id, { title: 'Renamed' })
 
     // The new path is created (marked for cache invalidation) and the old
     // path is trashed (marked so the delete listener skips the reload).
-    expect(store.consumeSelfWrite(task.filePath!)).toBe(true)
+    expect(store.consumeSelfWrite(expectDefined(task.filePath))).toBe(true)
     expect(store.consumeSelfWrite(oldPath)).toBe(true)
   })
 
@@ -95,8 +100,8 @@ describe('ProjectStore dirty-set save efficiency', () => {
     // No mutations, but force a save by updating a non-existent id.
     await store.updateTask(project, 'missing-id', {})
 
-    expect(vault.modifyCount.get(a.filePath!) ?? 0).toBe(0)
-    expect(vault.modifyCount.get(b.filePath!) ?? 0).toBe(0)
+    expect(vault.modifyCount.get(expectDefined(a.filePath)) ?? 0).toBe(0)
+    expect(vault.modifyCount.get(expectDefined(b.filePath)) ?? 0).toBe(0)
     expect(vault.modifyCount.get(project.filePath)).toBe(1)
   })
 
@@ -110,9 +115,9 @@ describe('ProjectStore dirty-set save efficiency', () => {
 
     await store.updateTask(project, b.id, { priority: 'high' })
 
-    expect(vault.modifyCount.get(a.filePath!) ?? 0).toBe(0)
-    expect(vault.modifyCount.get(b.filePath!)).toBe(1)
-    expect(vault.modifyCount.get(c.filePath!) ?? 0).toBe(0)
+    expect(vault.modifyCount.get(expectDefined(a.filePath)) ?? 0).toBe(0)
+    expect(vault.modifyCount.get(expectDefined(b.filePath))).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(c.filePath)) ?? 0).toBe(0)
   })
 
   it('rewrites direct children when a parent title changes', async () => {
@@ -126,10 +131,10 @@ describe('ProjectStore dirty-set save efficiency', () => {
     await store.updateTask(project, parent.id, { title: 'New parent' })
 
     // Parent file is renamed (create new + trash old), not modified.
-    expect(vault.modifyCount.get(parent.filePath!) ?? 0).toBe(0)
+    expect(vault.modifyCount.get(expectDefined(parent.filePath)) ?? 0).toBe(0)
     // Children stay at the same path but get rewritten because their Parent link broke.
-    expect(vault.modifyCount.get(child1.filePath!)).toBe(1)
-    expect(vault.modifyCount.get(child2.filePath!)).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(child1.filePath))).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(child2.filePath))).toBe(1)
   })
 
   it('rewrites both old and new parent on moveTask', async () => {
@@ -142,9 +147,9 @@ describe('ProjectStore dirty-set save efficiency', () => {
 
     await store.moveTask(project, child.id, p2.id)
 
-    expect(vault.modifyCount.get(p1.filePath!)).toBe(1)
-    expect(vault.modifyCount.get(p2.filePath!)).toBe(1)
-    expect(vault.modifyCount.get(child.filePath!)).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(p1.filePath))).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(p2.filePath))).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(child.filePath))).toBe(1)
   })
 
   it('rewrites the parent (not the deleted task) on deleteTask', async () => {
@@ -152,13 +157,13 @@ describe('ProjectStore dirty-set save efficiency', () => {
     const project = await store.createProject('Delete', 'Projects')
     const parent = await addNamed(store, project, 'Keep')
     const child = await addNamed(store, project, 'Goner', parent.id)
-    const childPath = child.filePath!
+    const childPath = expectDefined(child.filePath)
     vault.resetCounts()
 
     await store.deleteTask(project, child.id)
 
     expect(vault.trashCount.get(childPath)).toBe(1)
-    expect(vault.modifyCount.get(parent.filePath!)).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(parent.filePath))).toBe(1)
   })
 })
 
@@ -190,14 +195,14 @@ describe('ProjectStore round-trip', () => {
     expect(ids.has(b.id)).toBe(true)
     expect(ids.has(childOfA.id)).toBe(true)
 
-    const reloadedA = flat.find((f) => f.task.id === a.id)!.task
+    const reloadedA = expectDefined(flat.find((f) => f.task.id === a.id)).task
     expect(reloadedA.title).toBe('Design')
     expect(reloadedA.priority).toBe('high')
     expect(reloadedA.assignees).toEqual(['Alice'])
     expect(reloadedA.tags).toEqual(['design'])
     expect(reloadedA.subtasks.map((s) => s.id)).toEqual([childOfA.id])
 
-    const reloadedB = flat.find((f) => f.task.id === b.id)!.task
+    const reloadedB = expectDefined(flat.find((f) => f.task.id === b.id)).task
     expect(reloadedB.status).toBe('in-progress')
   })
 
@@ -299,7 +304,7 @@ describe('ProjectStore completion date', () => {
     if (!(file instanceof TFile)) throw new Error('project file missing')
     const reloaded = await store2.loadProject(file)
     if (!reloaded) throw new Error('reload failed')
-    const reloadedTask = flattenTasks(reloaded.tasks).find((f) => f.task.id === task.id)!.task
+    const reloadedTask = expectDefined(flattenTasks(reloaded.tasks).find((f) => f.task.id === task.id)).task
     expect(reloadedTask.completed).toMatch(ISO_DATE)
   })
 
@@ -400,7 +405,7 @@ describe('ProjectStore metadataCache fast path', () => {
     const { store, vault, app } = newStore()
     const project = await store.createProject('Cache', 'Projects')
     const task = await addNamed(store, project, 'cached task')
-    const taskPath = task.filePath!
+    const taskPath = expectDefined(task.filePath)
 
     stubTaskCache(app, taskPath, { 'pm-task': true, id: task.id, title: 'cached task' })
 
@@ -423,7 +428,7 @@ describe('ProjectStore metadataCache fast path', () => {
     const project = await store.createProject('Body', 'Projects')
     const task = await addNamed(store, project, 'task')
     await store.updateTask(project, task.id, { description: 'real description' })
-    const taskPath = task.filePath!
+    const taskPath = expectDefined(task.filePath)
 
     // Reload through a fresh store with cache hits — task arrives unhydrated.
     stubTaskCache(app, taskPath, {
@@ -449,7 +454,7 @@ describe('ProjectStore metadataCache fast path', () => {
     const project = await store.createProject('Preserve', 'Projects')
     const task = await addNamed(store, project, 'preserve me')
     await store.updateTask(project, task.id, { description: 'keep this' })
-    const taskPath = task.filePath!
+    const taskPath = expectDefined(task.filePath)
 
     stubTaskCache(app, taskPath, {
       'pm-task': true,
@@ -478,7 +483,7 @@ describe('ProjectStore metadataCache fast path', () => {
     const project = await store.createProject('Edit', 'Projects')
     const task = await addNamed(store, project, 'editable')
     await store.updateTask(project, task.id, { description: 'before' })
-    const taskPath = task.filePath!
+    const taskPath = expectDefined(task.filePath)
 
     stubTaskCache(app, taskPath, {
       'pm-task': true,
@@ -537,7 +542,7 @@ describe('ProjectStore task index', () => {
     expect(new Set(paths).size).toBe(paths.length)
     for (const p of paths) {
       expect(p).toBeTruthy()
-      expect(vault.getAbstractFileByPath(p!)).toBeInstanceOf(TFile)
+      expect(vault.getAbstractFileByPath(expectDefined(p))).toBeInstanceOf(TFile)
     }
   })
 
@@ -580,8 +585,8 @@ describe('ProjectStore concurrent-save race', () => {
     const project = await store.createProject('Race', 'Projects')
     const a = await addNamed(store, project, 'Alpha')
     const b = await addNamed(store, project, 'Beta')
-    const aOldPath = a.filePath!
-    const bOldPath = b.filePath!
+    const aOldPath = expectDefined(a.filePath)
+    const bOldPath = expectDefined(b.filePath)
     vault.resetCounts()
 
     // Kick off two updates back-to-back without awaiting the first.
@@ -613,9 +618,9 @@ describe('ProjectStore bulk mutators', () => {
     )
 
     expect(a.assignees).toEqual(['sam'])
-    expect(vault.modifyCount.get(a.filePath!)).toBe(1)
-    expect(vault.modifyCount.get(b.filePath!)).toBeUndefined()
-    const file = vault.getAbstractFileByPath(a.filePath!)
+    expect(vault.modifyCount.get(expectDefined(a.filePath))).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(b.filePath))).toBeUndefined()
+    const file = vault.getAbstractFileByPath(expectDefined(a.filePath))
     if (!(file instanceof TFile)) throw new Error('task file missing')
     expect(await vault.cachedRead(file)).toContain('sam')
   })
@@ -631,10 +636,10 @@ describe('ProjectStore bulk mutators', () => {
     await store.reorderTask(project, two.id, one.id, 'before')
 
     expect(parent.subtasks.map((t) => t.id)).toEqual([two.id, one.id])
-    expect(vault.modifyCount.get(parent.filePath!)).toBe(1)
-    expect(vault.modifyCount.get(one.filePath!)).toBeUndefined()
-    expect(vault.modifyCount.get(two.filePath!)).toBeUndefined()
-    const file = vault.getAbstractFileByPath(parent.filePath!)
+    expect(vault.modifyCount.get(expectDefined(parent.filePath))).toBe(1)
+    expect(vault.modifyCount.get(expectDefined(one.filePath))).toBeUndefined()
+    expect(vault.modifyCount.get(expectDefined(two.filePath))).toBeUndefined()
+    const file = vault.getAbstractFileByPath(expectDefined(parent.filePath))
     if (!(file instanceof TFile)) throw new Error('parent file missing')
     const content = await vault.cachedRead(file)
     expect(content.indexOf(two.id)).toBeLessThan(content.indexOf(one.id))
@@ -650,7 +655,7 @@ describe('ProjectStore bulk mutators', () => {
     await store.saveProject(project)
 
     expect(rogue.filePath).toBeDefined()
-    expect(vault.getAbstractFileByPath(rogue.filePath!)).not.toBeNull()
+    expect(vault.getAbstractFileByPath(expectDefined(rogue.filePath))).not.toBeNull()
   })
 })
 

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -450,10 +450,19 @@ export class ProjectStore {
   async saveProject(project: Project): Promise<void> {
     const key = project.filePath
     const prev = this.saveQueues.get(key) ?? Promise.resolve()
-    const next = prev.then(() => this.doSaveProject(project))
+    const next = (async () => {
+      await prev
+      await this.doSaveProject(project)
+    })()
     this.saveQueues.set(
       key,
-      next.catch(() => {})
+      (async () => {
+        try {
+          await next
+        } catch {
+          // swallow so the next queued save still runs after a failure
+        }
+      })()
     )
     return next
   }
@@ -948,7 +957,7 @@ export class ProjectStore {
   }
 
   private async deleteFolderRecursive(folder: TFolder): Promise<void> {
-    for (const child of [...folder.children]) {
+    for (const child of folder.children.slice()) {
       if (child instanceof TFile) {
         this.markSelfWrite(child.path)
         await this.app.fileManager.trashFile(child)

--- a/src/store/Scheduler.ts
+++ b/src/store/Scheduler.ts
@@ -50,7 +50,8 @@ export function wouldCreateCycle(tasks: Task[], fromId: string, toId: string): b
   const visited = new Set<string>()
   const queue = [fromId]
   while (queue.length > 0) {
-    const current = queue.shift()!
+    const current = queue.shift()
+    if (current === undefined) break
     if (current === toId) return true
     if (visited.has(current)) continue
     visited.add(current)
@@ -101,7 +102,8 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
     scopeIds = new Set<string>()
     const queue = [changedTaskId]
     while (queue.length > 0) {
-      const id = queue.shift()!
+      const id = queue.shift()
+      if (id === undefined) break
       if (scopeIds.has(id)) continue
       scopeIds.add(id)
       for (const depId of dependentsOf.get(id) ?? []) {
@@ -128,11 +130,13 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
 
   const topoOrder: string[] = []
   while (queue.length > 0) {
-    const id = queue.shift()!
+    const id = queue.shift()
+    if (id === undefined) break
     topoOrder.push(id)
     for (const depId of dependentsOf.get(id) ?? []) {
-      if (!inDegree.has(depId)) continue
-      const newDeg = inDegree.get(depId)! - 1
+      const currentDeg = inDegree.get(depId)
+      if (currentDeg === undefined) continue
+      const newDeg = currentDeg - 1
       inDegree.set(depId, newDeg)
       if (newDeg === 0) queue.push(depId)
     }
@@ -155,7 +159,8 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
   const patches: SchedulePatch[] = []
 
   for (const id of topoOrder) {
-    const task = taskById.get(id)!
+    const task = taskById.get(id)
+    if (!task) continue
 
     // Skip done/cancelled tasks
     if (isTerminalStatus(task.status, statuses)) continue

--- a/src/store/TaskIndex.test.ts
+++ b/src/store/TaskIndex.test.ts
@@ -10,6 +10,11 @@ import {
   rebuildTaskIndex
 } from './TaskIndex'
 
+const expectDefined = <T>(value: T | null | undefined, message = 'expected value to be defined'): T => {
+  if (value == null) throw new Error(message)
+  return value
+}
+
 function tree(): Task[] {
   return [
     makeTask({
@@ -86,7 +91,7 @@ describe('indexAddSubtree / indexRemoveSubtree / indexSetParent', () => {
     const project = makeProject('P', 'P.md')
     project.tasks = tree()
     rebuildTaskIndex(project)
-    const a = findTaskById(project, 'a')!
+    const a = expectDefined(findTaskById(project, 'a'))
     indexRemoveSubtree(project, a)
     expect(findTaskById(project, 'a')).toBeNull()
     expect(findTaskById(project, 'a1')).toBeNull()

--- a/src/ui/FormField.ts
+++ b/src/ui/FormField.ts
@@ -34,7 +34,8 @@ export function renderChipList(container: HTMLElement, items: string[], opts: Ch
   if (opts.renderAdd) {
     opts.renderAdd(container)
   } else if (opts.onAdd) {
-    new ButtonComponent(container).setButtonText(opts.addLabel ?? '+ Add').onClick((e) => opts.onAdd!(e))
+    const onAdd = opts.onAdd
+    new ButtonComponent(container).setButtonText(opts.addLabel ?? '+ Add').onClick((e) => onAdd(e))
   }
 }
 

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -238,7 +238,11 @@ export function openTaskModal(plugin: PMPlugin, project: Project, opts: OpenTask
   // body is read. Pre-load (no-op if already hydrated) so the modal renders the
   // real description in one paint.
   if (opts.task) {
-    void plugin.store.loadTaskBody(opts.task).then(open)
+    const task = opts.task
+    void (async () => {
+      await plugin.store.loadTaskBody(task)
+      open()
+    })()
   } else {
     open()
   }
@@ -254,7 +258,11 @@ export function openProjectModal(plugin: PMPlugin, opts: OpenProjectModalOpts): 
     new ProjectModal(plugin.app, plugin, opts.project ?? null, opts.onSave).open()
   }
   if (opts.project) {
-    void plugin.store.loadProjectBody(opts.project).then(open)
+    const project = opts.project
+    void (async () => {
+      await plugin.store.loadProjectBody(project)
+      open()
+    })()
   } else {
     open()
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,10 +92,14 @@ export function formatBadgeText(icon: string | undefined, label: string): string
 /** Wrap an async callback so unhandled rejections show a Notice and log to console */
 export function safeAsync<A extends unknown[]>(fn: (...args: A) => Promise<void>): (...args: A) => void {
   return (...args: A) => {
-    fn(...args).catch((err: unknown) => {
-      console.error('[PM]', err)
-      new Notice('Something went wrong. Check the console for details.')
-    })
+    void (async () => {
+      try {
+        await fn(...args)
+      } catch (err: unknown) {
+        console.error('[PM]', err)
+        new Notice('Something went wrong. Check the console for details.')
+      }
+    })()
   }
 }
 

--- a/src/views/gantt/GanttLinkHandler.ts
+++ b/src/views/gantt/GanttLinkHandler.ts
@@ -54,6 +54,12 @@ export function handleLinkDotClick(
     return
   }
 
+  const otherTaskId = link.taskId
+  if (otherTaskId === null) {
+    cancelLink(link)
+    return
+  }
+
   // Same side — invalid (need one left + one right)
   if (link.side === side) {
     new Notice('Connect a right dot (output) to a left dot (input).')
@@ -62,8 +68,8 @@ export function handleLinkDotClick(
 
   // Determine predecessor (right dot) and successor (left dot)
   // Finish-to-start: successor.dependencies includes predecessor.id
-  const predecessorId = side === 'right' ? taskId : link.taskId!
-  const successorId = side === 'left' ? taskId : link.taskId!
+  const predecessorId = side === 'right' ? taskId : otherTaskId
+  const successorId = side === 'left' ? taskId : otherTaskId
 
   cancelLink(link)
 

--- a/src/views/gantt/GanttTaskBarRenderer.ts
+++ b/src/views/gantt/GanttTaskBarRenderer.ts
@@ -52,7 +52,8 @@ export function renderTaskBar(g: SVGGElement, task: Task, row: number, _depth: n
 
   // Normal task bar. A task with end date E occupies the day E, so the bar
   // right edge sits at the start of E+1.
-  const effectiveStart = startDate ?? endDate!
+  const effectiveStart = startDate ?? endDate
+  if (!effectiveStart) return
   const effectiveEnd = (endDate ?? effectiveStart).add({ days: 1 })
 
   const x = Math.max(0, dateToX(ctx.cfg, effectiveStart))

--- a/src/views/table/BulkActionBar.ts
+++ b/src/views/table/BulkActionBar.ts
@@ -224,8 +224,8 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
       ctx.state.selectedTaskIds.clear()
       if (ctx.state.tableBody) {
         const cbs = ctx.state.tableBody.querySelectorAll('.pm-select-checkbox')
-        cbs.forEach((cb) => {
-          ;(cb as HTMLInputElement).checked = false
+        cbs.forEach((checkbox) => {
+          ;(checkbox as HTMLInputElement).checked = false
         })
       }
       updateSelectAllCheckbox(ctx.state)

--- a/src/views/table/TableRenderer.ts
+++ b/src/views/table/TableRenderer.ts
@@ -268,7 +268,8 @@ export function updateSelectCheckboxes(state: TableState): void {
   if (!state.tableBody) return
   const rows = state.tableBody.querySelectorAll('tr[data-task-id]')
   for (const row of Array.from(rows)) {
-    const id = (row as HTMLElement).dataset.taskId!
+    const id = (row as HTMLElement).dataset.taskId
+    if (id === undefined) continue
     const cb = row.querySelector('.pm-select-checkbox')
     if (cb) (cb as HTMLInputElement).checked = state.selectedTaskIds.has(id)
   }

--- a/test/fakeVault.ts
+++ b/test/fakeVault.ts
@@ -1,6 +1,11 @@
 import { TAbstractFile, TFile, TFolder, normalizePath, parseYaml } from 'obsidian'
 import { appendYaml } from '../src/store/YamlParser'
 
+const expectDefined = <T>(value: T | null | undefined, message = 'expected value to be defined'): T => {
+  if (value == null) throw new Error(message)
+  return value
+}
+
 interface FileContent {
   file: TFile
   content: string
@@ -119,7 +124,7 @@ export class FakeVault {
 
   async trashFile(file: TAbstractFile): Promise<void> {
     if (file instanceof TFolder) {
-      for (const child of [...file.children]) await this.trashFile(child)
+      for (const child of file.children.slice()) await this.trashFile(child)
       this.folders.delete(file.path)
       detachFromParent(file)
       bump(this.trashCount, file.path)
@@ -140,7 +145,7 @@ export class FakeVault {
 
   private ensureFolderForPath(path: string): TFolder {
     const idx = path.lastIndexOf('/')
-    if (idx < 0) return this.folders.get('')!
+    if (idx < 0) return expectDefined(this.folders.get(''))
     const parentPath = path.slice(0, idx)
     const existing = this.folders.get(parentPath)
     if (existing) return existing

--- a/test/obsidian-stub.ts
+++ b/test/obsidian-stub.ts
@@ -3,7 +3,6 @@ import { parse } from 'yaml'
 export const parseYaml = (raw: string): unknown => parse(raw)
 
 export class Notice {
-  constructor(_message?: string | DocumentFragment, _timeout?: number) {}
   hide(): void {}
 }
 


### PR DESCRIPTION
Clears oxlint warnings: drops non-null assertions, moves promise chains to async/await, removes a dead callback setter, and switches two defensive array copies off spread syntax. No behavior change.