### PR TITLE
clear obsidian plugin review warnings

### DIFF
--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -276,7 +276,7 @@ export class TaskModal extends Modal {
       const items = e.clipboardData?.items
       if (!items) return
       const attachments: { blob: Blob; name: string }[] = []
-      for (const item of items) {
+      for (const item of Array.from(items)) {
         if (item.kind === 'file' && item.type.startsWith('image/')) {
           const file = item.getAsFile()
           if (file) {

--- a/src/styles/kanban.css
+++ b/src/styles/kanban.css
@@ -2,7 +2,7 @@
    KANBAN BOARD
    --------------------------------------------------------------------------- */
 /* When kanban is active, prevent parent from scrolling so flex height works */
-.pm-content:has(.pm-kanban-view) {
+.pm-content--kanban {
   overflow: hidden;
 }
 

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -63,7 +63,13 @@ body.pm-resize-active * {
 
 /* -- Gantt label "+" subtask button ------------------------------------ */
 .pm-gantt-label-add-btn {
-  all: unset;
+  appearance: none;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
   cursor: pointer;
   font-size: 14px;
   font-weight: 700;

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -36,7 +36,12 @@
   gap: 6px;
 }
 .pm-segmented-btn {
-  all: unset;
+  appearance: none;
+  background: none;
+  border: none;
+  margin: 0;
+  font: inherit;
+  color: inherit;
   cursor: pointer;
   padding: 4px 12px;
   border-radius: var(--pm-radius-sm);
@@ -296,7 +301,7 @@
 }
 .pm-modal-desc-preview a {
   color: var(--interactive-accent);
-  text-decoration: underline;
+  text-decoration-line: underline;
   cursor: pointer;
   transition: color 0.15s;
 }
@@ -383,7 +388,13 @@
 
 /* -- Gantt add task button --------------------------------------------- */
 .pm-gantt-add-task-btn {
-  all: unset;
+  appearance: none;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
   cursor: pointer;
   font-size: 12px;
   color: var(--pm-text-muted);

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -418,6 +418,7 @@ export class ProjectView extends ItemView {
         this.subview = new KanbanView(this.bodyEl, this.project, this.plugin, () => this.refreshProject(), this.filter)
         break
     }
+    this.bodyEl.toggleClass('pm-content--kanban', this.currentView === 'kanban')
     this.subview?.render()
   }
 


### PR DESCRIPTION
Replaces the CSS `all` resets, the `:has` kanban selector, and the `text-decoration` shorthand with supported equivalents, and types pasted clipboard items so the access isn't `any`. No behavior change.