### PR TITLE
default new subtasks to the subtask type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Gantt today marker, milestone and subtask buttons, and row selection and hover highlights take their colors from the theme instead of fixed values
 - Kanban cards align the assignee and due date to the bottom of the card
 
+### Fixed
+
+- Subtasks created from a task's subtasks list or the add-subtask buttons are set to the subtask type automatically ([#82](https://github.com/StepanKropachev/obsidian-pm/issues/82))
+
 ## [1.6.0] - 2026-06-12
 
 ### Added

--- a/src/modals/SubtasksPanel.ts
+++ b/src/modals/SubtasksPanel.ts
@@ -48,7 +48,7 @@ export function renderSubtasksPanel(container: HTMLElement, task: Task, plugin: 
   renderSubtasks()
 
   addSubBtn.onClick(() => {
-    const newSub = makeTask({ title: 'New subtask' })
+    const newSub = makeTask({ title: 'New subtask', type: 'subtask' })
     task.subtasks.push(newSub)
     renderSubtasks()
     window.setTimeout(() => {

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -43,6 +43,7 @@ export class TaskModal extends Modal {
       this.task = makeTask({
         status: getDefaultStatusId(plugin.settings.statuses),
         priority: 'medium',
+        type: parentId ? 'subtask' : 'task',
         ...defaults
       })
       this.isNew = true


### PR DESCRIPTION
New subtasks get the subtask type automatically, so you don't have to set it on each one to make them show up as subtasks on the board. Fixes #82.