### PR TITLE
resolve assignee note links to names on avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Subtasks created from a task's subtasks list or the add-subtask buttons are set to the subtask type automatically ([#82](https://github.com/StepanKropachev/obsidian-pm/issues/82))
+- Assignees written as note links (`[[People/Jane Doe]]`) show the person's name on their avatar instead of the link path ([#64](https://github.com/StepanKropachev/obsidian-pm/issues/64))
 
 ## [1.6.0] - 2026-06-12
 

--- a/src/ui/primitives/Avatar.test.ts
+++ b/src/ui/primitives/Avatar.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { displayName } from './Avatar'
+
+describe('displayName', () => {
+  it('returns a plain name unchanged', () => {
+    expect(displayName('Jane Doe')).toBe('Jane Doe')
+  })
+
+  it('trims a plain name', () => {
+    expect(displayName('  Jane Doe  ')).toBe('Jane Doe')
+  })
+
+  it('unwraps a bare wikilink', () => {
+    expect(displayName('[[Jane Doe]]')).toBe('Jane Doe')
+  })
+
+  it('strips the folder path from a bare wikilink', () => {
+    expect(displayName('[[People/Team/Jane Doe]]')).toBe('Jane Doe')
+  })
+
+  it('prefers the alias when present', () => {
+    expect(displayName('[[People/Jane Doe|JD]]')).toBe('JD')
+  })
+
+  it('trims the alias', () => {
+    expect(displayName('[[People/Jane Doe| JD ]]')).toBe('JD')
+  })
+
+  it('falls back to the path when the alias is empty', () => {
+    expect(displayName('[[People/Jane Doe|]]')).toBe('Jane Doe')
+  })
+
+  it('drops a file extension', () => {
+    expect(displayName('[[People/Jane Doe.md]]')).toBe('Jane Doe')
+  })
+
+  it('drops a heading reference', () => {
+    expect(displayName('[[People/Jane Doe#Bio]]')).toBe('Jane Doe')
+  })
+
+  it('drops a block reference', () => {
+    expect(displayName('[[People/Jane Doe#^abc123]]')).toBe('Jane Doe')
+  })
+
+  it('keeps a dot inside a name', () => {
+    expect(displayName('[[People/Jane.Doe]]')).toBe('Jane.Doe')
+  })
+
+  it('keeps a version-style name with a dot', () => {
+    expect(displayName('[[v1.2 release]]')).toBe('v1.2 release')
+  })
+
+  it('leaves a non-wikilink string with brackets alone', () => {
+    expect(displayName('[[unterminated')).toBe('[[unterminated')
+  })
+})

--- a/src/ui/primitives/Avatar.ts
+++ b/src/ui/primitives/Avatar.ts
@@ -1,12 +1,20 @@
-import { setTooltip } from 'obsidian'
+import { parseLinktext, setTooltip } from 'obsidian'
 import { stringToColor } from '../../utils'
 
-function displayName(raw: string): string {
-  const m = raw.trim().match(/^\[\[([^\]]+)\]\]$/)
-  if (!m) return raw
+export function displayName(raw: string): string {
+  const trimmed = raw.trim()
+  const m = trimmed.match(/^\[\[([^\]]+)\]\]$/)
+  if (!m) return trimmed
   const inner = m[1]
   const pipe = inner.indexOf('|')
-  return pipe >= 0 ? inner.slice(pipe + 1) : inner
+  if (pipe >= 0) {
+    const alias = inner.slice(pipe + 1).trim()
+    if (alias) return alias
+  }
+  const target = pipe >= 0 ? inner.slice(0, pipe) : inner
+  const { path } = parseLinktext(target)
+  const base = path.split('/').pop() ?? path
+  return (base.endsWith('.md') ? base.slice(0, -3) : base).trim()
 }
 
 function initialsFor(name: string): string {

--- a/test/obsidian-stub.ts
+++ b/test/obsidian-stub.ts
@@ -10,6 +10,13 @@ export function normalizePath(p: string): string {
   return p.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/^\/+/, '').replace(/\/+$/, '')
 }
 
+export function parseLinktext(linktext: string): { path: string; subpath: string } {
+  const hash = linktext.indexOf('#')
+  return hash < 0
+    ? { path: linktext, subpath: '' }
+    : { path: linktext.slice(0, hash), subpath: linktext.slice(hash) }
+}
+
 export class TAbstractFile {
   path = ''
   name = ''


### PR DESCRIPTION
Avatars for assignees stored as `[[note links]]` now show the person's name instead of the link path. Closes #64.