### PR TITLE
update changelog for 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-06-15
+
 ### Changed
 
 - Task and project modals use Obsidian's native border, shadow, and corner styling instead of custom values


### PR DESCRIPTION
Roll the unreleased changes into a 1.6.1 section ahead of the release.