### PR TITLE
refresh the project list when tasks change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The project list updates its task counts when tasks are added, changed, or removed instead of staying stale until the view is reopened ([#121](https://github.com/StepanKropachev/obsidian-pm/issues/121))
+
 ## [1.6.1] - 2026-06-15
 
 ### Changed

--- a/src/views/DashboardView.ts
+++ b/src/views/DashboardView.ts
@@ -10,6 +10,7 @@ export class DashboardView extends ItemView {
   private toolbarEl!: HTMLElement
   private bodyEl!: HTMLElement
   private renderToken = 0
+  private reloadDebounceTimer: number | null = null
 
   constructor(leaf: WorkspaceLeaf, plugin: PMPlugin) {
     super(leaf)
@@ -35,7 +36,40 @@ export class DashboardView extends ItemView {
     this.toolbarEl = root.createDiv('pm-toolbar')
     this.bodyEl = root.createDiv('pm-content')
     this.render()
+    this.registerVaultListeners()
     return Promise.resolve()
+  }
+
+  onClose(): Promise<void> {
+    if (this.reloadDebounceTimer !== null) {
+      window.clearTimeout(this.reloadDebounceTimer)
+      this.reloadDebounceTimer = null
+    }
+    return Promise.resolve()
+  }
+
+  private registerVaultListeners(): void {
+    const isRelevant = (path: string) => {
+      const folder = this.plugin.settings.projectsFolder
+      return path === folder || path.startsWith(`${folder}/`)
+    }
+    const scheduleReload = (path: string) => {
+      if (!isRelevant(path)) return
+      if (this.reloadDebounceTimer !== null) window.clearTimeout(this.reloadDebounceTimer)
+      this.reloadDebounceTimer = window.setTimeout(() => {
+        this.reloadDebounceTimer = null
+        this.render()
+      }, 300)
+    }
+    this.registerEvent(this.app.vault.on('create', (file) => scheduleReload(file.path)))
+    this.registerEvent(this.app.vault.on('modify', (file) => scheduleReload(file.path)))
+    this.registerEvent(this.app.vault.on('delete', (file) => scheduleReload(file.path)))
+    this.registerEvent(
+      this.app.vault.on('rename', (file, oldPath) => {
+        scheduleReload(file.path)
+        scheduleReload(oldPath)
+      })
+    )
   }
 
   render(): void {


### PR DESCRIPTION
The project list didn't refresh after it first rendered, so per-project task counts stayed stale until you reopened the view. Now it watches for task file changes (create/modify/delete/rename) under the projects folder and re-renders. Fixes #121.