### PR TITLE
clear css lint warnings in style partials

### DIFF
--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -69,7 +69,6 @@ body.pm-resize-active * {
   margin: 0;
   padding: 0;
   font: inherit;
-  color: inherit;
   cursor: pointer;
   font-size: 14px;
   font-weight: 700;

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -38,10 +38,8 @@
 .pm-segmented-btn {
   appearance: none;
   background: none;
-  border: none;
   margin: 0;
   font: inherit;
-  color: inherit;
   cursor: pointer;
   padding: 4px 12px;
   border-radius: var(--pm-radius-sm);
@@ -301,13 +299,12 @@
 }
 .pm-modal-desc-preview a {
   color: var(--interactive-accent);
-  text-decoration-line: underline;
+  text-decoration: underline;
   cursor: pointer;
   transition: color 0.15s;
 }
 .pm-modal-desc-preview a:hover {
   color: var(--interactive-accent-hover);
-  text-decoration-thickness: 2px;
 }
 .pm-modal-desc-preview a.external-link {
   color: var(--interactive-accent);
@@ -392,9 +389,7 @@
   background: none;
   border: none;
   margin: 0;
-  padding: 0;
   font: inherit;
-  color: inherit;
   cursor: pointer;
   font-size: 12px;
   color: var(--pm-text-muted);


### PR DESCRIPTION
Drops the duplicate color/border/padding declarations in the button-reset blocks and swaps the text-decoration longhands for the supported shorthand, clearing the plugin linter warnings. The !important hidden/resize-cursor utilities are left as-is since they need the override.